### PR TITLE
🚀 sum

### DIFF
--- a/.changeset/young-kids-protect.md
+++ b/.changeset/young-kids-protect.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/hidash": patch
+---
+
+🚀 sum

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ const moduleMap = {
     isArray: './src/isArray.ts',
     isObject: './src/isObject.ts',
     has: './src/has.ts',
+    sum: './src/sum.ts',
 } as const
 
 export default moduleMap

--- a/package.json
+++ b/package.json
@@ -79,6 +79,16 @@
                 "types": "./has.d.ts",
                 "default": "./has.js"
             }
+        },
+        "./sum": {
+            "import": {
+                "types": "./sum.d.mts",
+                "default": "./sum.mjs"
+            },
+            "require": {
+                "types": "./sum.d.ts",
+                "default": "./sum.js"
+            }
         }
     },
     "scripts": {

--- a/src/sum.bench.ts
+++ b/src/sum.bench.ts
@@ -1,0 +1,63 @@
+import _sum from 'lodash/sum'
+import {bench, describe} from 'vitest'
+
+import sum from './sum'
+
+const testCases = [
+    // Empty array
+    [[]],
+    // Simple arrays
+    [[1, 2, 3, 4, 5]],
+    [[0.1, 0.2, 0.3]],
+    // Negative numbers
+    [[-1, -2, -3, -4, -5]],
+    // Mixed positive and negative
+    [[1, -2, 3, -4, 5]],
+    // Large arrays
+    [Array(1000).fill(1)],
+    [Array(1000).map((_, i) => i)],
+    // Decimal numbers
+    [[0.1, 0.01, 0.001, 0.0001]],
+    // Large numbers
+    [[Number.MAX_SAFE_INTEGER, 1, 2, 3]],
+    // Small numbers
+    [[Number.MIN_SAFE_INTEGER, -1, -2, -3]],
+    // Arrays with zeros
+    [[0, 0, 0, 0, 0]],
+    [[1, 0, 2, 0, 3]],
+    // Single element
+    [[42]],
+    // Repeated numbers
+    [[1, 1, 1, 1, 1]],
+    // Scientific notation
+    [[1e5, 1e4, 1e3]],
+    // Various lengths
+    [Array(10).fill(1)],
+    [Array(100).fill(1)],
+    [Array(1000).fill(1)],
+    // Random numbers
+    [Array(100).map(() => Math.random() * 100)],
+    // Edge cases with Number limits
+    [[Number.MAX_VALUE, 1]],
+    [[Number.MIN_VALUE, -1]],
+] as const
+
+const ITERATIONS = 1000
+
+describe('sum performance', () => {
+    bench('hidash', () => {
+        for (let i = 0; i < ITERATIONS; i++) {
+            testCases.forEach(([arr]) => {
+                sum(arr)
+            })
+        }
+    })
+
+    bench('lodash', () => {
+        for (let i = 0; i < ITERATIONS; i++) {
+            testCases.forEach(([arr]) => {
+                _sum(arr)
+            })
+        }
+    })
+})

--- a/src/sum.test.ts
+++ b/src/sum.test.ts
@@ -1,0 +1,13 @@
+import _sum from 'lodash/sum'
+import {describe, it, expect} from 'vitest'
+
+import sum from './sum'
+
+describe('sum', () => {
+    it('number array check', () => {
+        expect(sum([])).toBe(0)
+        expect(sum([])).toEqual(_sum([]))
+        expect(sum([4, 2, 8, 6])).toBe(20)
+        expect(sum([4, 2, 8, 6])).toEqual(_sum([4, 2, 8, 6]))
+    })
+})

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -1,0 +1,10 @@
+/**
+ * @description https://unpkg.com/lodash.sum lodash.sum is only compatible with number arrays
+ */
+export default function sum(elements: number[]): number {
+    let result = 0
+    for (const element of elements) {
+        result += element
+    }
+    return result
+}

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -3,7 +3,7 @@
  */
 export function sum(elements: number[]): number {
     let result = 0
-    // for-of is slower than index
+    // for-of is slower than indexed for loop
     // eslint-disable-next-line
     for (let i = 0; i < elements.length; i++) {
         result += elements[i]

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -1,10 +1,14 @@
 /**
  * @description https://unpkg.com/lodash.sum lodash.sum is only compatible with number arrays
  */
-export default function sum(elements: number[]): number {
+export function sum(elements: number[]): number {
     let result = 0
-    for (const element of elements) {
-        result += element
+    // for-of is slower than index
+    // eslint-disable-next-line
+    for (let i = 0; i < elements.length; i++) {
+        result += elements[i]
     }
     return result
 }
+
+export default sum


### PR DESCRIPTION
this closes #27 

```bash
 ✓ src/sum.bench.ts (2) 1262ms
   ✓ sum performance (2) 1261ms
     name         hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · hidash   233.08   4.0823   4.4680   4.2903   4.3025   4.3631   4.4680   4.4680  ±0.17%      117   fastest
   · lodash  70.1529  14.1454  14.4924  14.2546  14.2945  14.4924  14.4924  14.4924  ±0.22%       36

  hidash - src/sum.bench.ts > sum performance
    3.32x faster than lodash
```

