### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/silver-dancers-carry.md
+++ b/.changeset/silver-dancers-carry.md
@@ -1,7 +1,0 @@
----
-"@naverpay/hidash": patch
----
-
-🚀 `toNumber`, `isSymbol`
-
-[🚀 toNumber, isSymbol](https://github.com/NaverPayDev/hidash/pull/113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/hidash
 
+## 0.1.2
+
+### Patch Changes
+
+-   d1dcd07: 🚀 `toNumber`, `isSymbol`
+
+    [🚀 toNumber, isSymbol](https://github.com/NaverPayDev/hidash/pull/113)
+
 ## 0.1.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/hidash",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "improved lodash",
     "sideEffects": false,
     "files": [


### PR DESCRIPTION
# Releases
## @naverpay/hidash@0.1.2

### Patch Changes

-   d1dcd07: 🚀 `toNumber`, `isSymbol`

    [🚀 toNumber, isSymbol](https://github.com/NaverPayDev/hidash/pull/113)
