### PR TITLE
📝 Add comments on why exceptions are needed

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -21,18 +21,12 @@ export default defineConfig({
                         version: '3.38.1',
                         proposals: true,
                         exclude: [
-                            // https://bugs.chromium.org/p/v8/issues/detail?id=12681
-                            'es.array.push',
-                            // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
-                            'es.array.includes',
-                            // TODO: replace (Safari 12.1)
-                            'es.object.from-entries', // mapValues.ts
-                            // https://issues.chromium.org/issues/40672866
-                            'es.array.reduce',
-                            // TODO: replace (Safari 12)
-                            'es.array.flat-map', // omit.ts
-                            // TODO: replace (Safari 12.1)
-                            'es.string.trim', // toNumber.ts
+                            'es.array.push', // https://bugs.chromium.org/p/v8/issues/detail?id=12681
+                            'es.array.includes', // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
+                            'es.object.from-entries', // TODO: replace mapValues.ts (Safari 12.1)
+                            'es.array.reduce', // https://issues.chromium.org/issues/40672866
+                            'es.array.flat-map', // TODO: replace omit.ts (Safari 12)
+                            'es.string.trim', // TODO: replace toNumber.ts (Safari 12.1)
                         ],
                     },
                 ],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -21,11 +21,17 @@ export default defineConfig({
                         version: '3.38.1',
                         proposals: true,
                         exclude: [
+                            // https://bugs.chromium.org/p/v8/issues/detail?id=12681
                             'es.array.push',
-                            'es.array.includes', // has.ts
+                            // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
+                            'es.array.includes',
+                            // TODO: replace (Safari 12.1)
                             'es.object.from-entries', // mapValues.ts
-                            'es.array.reduce', // mapValues.ts
+                            // https://issues.chromium.org/issues/40672866
+                            'es.array.reduce',
+                            // TODO: replace (Safari 12)
                             'es.array.flat-map', // omit.ts
+                            // TODO: replace (Safari 12.1)
                             'es.string.trim', // toNumber.ts
                         ],
                     },


### PR DESCRIPTION
## why

- `es.array.push`와 같이 구현자체는 오래되었으나 엔진 버그등으로 인해 core-js 에서 폴리필이 추가되는 경우가 있습니다.
- 이러한 경우에는 hidash, pite 모두 폴리필이 추가되지 않았으면 합니다. 의견 부탁드립니다!
  - 버그가 발생할 동작을 사용하지 않음
  - 아주 지극히 예외 적인 상황에서만 발생하는 오류: 폴리필 추가 비용이 더 쓸모없음
- 나머지 애들은 실제로 현재 범위에서 지원하지 않는 메서드로 예외 처리 필요 ;ㅁ;

### es.array.push

```js
// 1. 빈 배열 생성
const arr = [];

// 2. 배열의 length를 비작성 가능(non-writable)으로 설정
Object.defineProperty(arr, 'length', { writable: false });

// 3. push()를 호출 (인자를 전달하지 않음)
arr.push(); // 기존 Chrome에서는 오류가 발생하지 않음 (무시됨)

// 그러나 명세에 따르면 `length` 속성은 업데이트하려다 실패해야 하고, TypeError를 던져야 함.
```

### es.array.includes

```js
// 스파스 배열 생성
const sparseArray1 = [ , ];  // sparse array, 길이 1
const sparseArray2 = Array(1);  // 동일한 sparse array 생성 방식

// includes(undefined) 호출
console.log(sparseArray1.includes(undefined)); // true, 올바른 동작
console.log(sparseArray2.includes(undefined)); // false, 잘못된 동작
```

### es.array.reduce

https://issues.chromium.org/issues/40672866

내부 구현을 최적화 시도하였으나, 비결정적 동작 문제가 발생하여 리버트 한듯
https://chromium.googlesource.com/v8/v8.git/+/c0fbfcd81cd9f63f6a8be685397ebda33b6b2f2b
아주 간헐적으로 발생하는 문제
```bash
2949 invocations -> error always happens during 1839th invocation
2337 invocations -> error always happens during 1398th invocation
3125 invocations -> error always happens during 1787th invocation
2198 invocations -> error always happens during 1395th invocation
```
