### PR TITLE
remove some polyfill from allow list

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
     "extends": "@naverpay/eslint-config",
     "rules": {
-        "@typescript-eslint/naming-convention": ["off"]
+        "@typescript-eslint/naming-convention": ["off"],
+        "@typescript-eslint/prefer-for-of": ["off"]
     }
 }

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -32,7 +32,13 @@ function deepClone<T>(value: T): T {
     if (Array.isArray(value)) {
         return value.map(deepClone) as T
     } else if (isObject(value)) {
-        return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, deepClone(v)])) as T
+        const result = {} as T
+        for (const key in value) {
+            if (Object.prototype.hasOwnProperty.call(value, key)) {
+                result[key] = deepClone(value[key])
+            }
+        }
+        return result
     }
     return value
 }

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -6,11 +6,22 @@ export function omit<T extends object>(object: T | null | undefined, ...paths: P
     }
 
     const result = {...object}
-    const flattenedPaths = paths.flatMap((path) => (Array.isArray(path) ? path : [path]))
+    const flattenedPaths: PropertyPath[] = []
 
-    flattenedPaths.forEach((path) => {
-        delete result[path as keyof T]
-    })
+    for (let i = 0; i < paths.length; i++) {
+        const path = paths[i]
+        if (Array.isArray(path)) {
+            for (let j = 0; j < path.length; j++) {
+                flattenedPaths.push(path[j])
+            }
+        } else {
+            flattenedPaths.push(path)
+        }
+    }
+
+    for (let i = 0; i < flattenedPaths.length; i++) {
+        delete result[flattenedPaths[i] as keyof T]
+    }
 
     return result
 }

--- a/src/shuffle.ts
+++ b/src/shuffle.ts
@@ -9,7 +9,12 @@ export function shuffle<T>(collection: Collection<T> | null | undefined): T[] {
     }
     let result: T[]
     if (collection instanceof Map) {
-        result = Array.from(collection.entries()).flatMap(([key, value]) => [key as unknown as T, value as T])
+        result = []
+        const entries = Array.from(collection.entries())
+        for (let i = 0; i < entries.length; i++) {
+            result.push(entries[i][0] as unknown as T)
+            result.push(entries[i][1] as T)
+        }
     } else if (collection instanceof Set) {
         result = Array.from(collection)
     } else if (typeof collection === 'string' || isArray(collection)) {
@@ -32,4 +37,5 @@ export function shuffle<T>(collection: Collection<T> | null | undefined): T[] {
     }
     return result
 }
+
 export default shuffle

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -23,7 +23,6 @@ export default defineConfig({
                         exclude: [
                             'es.array.push', // https://bugs.chromium.org/p/v8/issues/detail?id=12681
                             'es.array.includes', // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
-                            'es.object.from-entries', // TODO: replace mapValues.ts (Safari 12.1)
                             'es.array.reduce', // https://issues.chromium.org/issues/40672866
                             'es.array.flat-map', // TODO: replace omit.ts (Safari 12)
                             'es.string.trim', // TODO: replace toNumber.ts (Safari 12.1)

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -24,7 +24,6 @@ export default defineConfig({
                             'es.array.push', // https://bugs.chromium.org/p/v8/issues/detail?id=12681
                             'es.array.includes', // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
                             'es.array.reduce', // https://issues.chromium.org/issues/40672866
-                            'es.array.flat-map', // TODO: replace omit.ts (Safari 12)
                             'es.string.trim', // TODO: replace toNumber.ts (Safari 12.1)
                         ],
                     },

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -24,7 +24,7 @@ export default defineConfig({
                             'es.array.push', // https://bugs.chromium.org/p/v8/issues/detail?id=12681
                             'es.array.includes', // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
                             'es.array.reduce', // https://issues.chromium.org/issues/40672866
-                            'es.string.trim', // TODO: replace toNumber.ts (Safari 12.1)
+                            'es.string.trim', // https://github.com/zloirock/core-js/issues/480#issuecomment-457494016 safari bug
                         ],
                     },
                 ],


### PR DESCRIPTION
- Implement it in a different way without using `fromEntries` and `flatMap`.
- `trim` is confirmed as a usable ES5 method , so it will be added to the usage list. (Found information about a Safari bug, but couldn't locate the exact bug issue 😭 see comments).