### PR TITLE
Improve the Benchmark CI to run only for modules changed in the Pull Request.

### DIFF
--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -35,14 +35,26 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Run benchmark
-              run: pnpm bench
+            - name: Identify modified utility files
+              id: modified_files
+              run: |
+                  MODIFIED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} -- 'src/**/*.ts' ':!src/**/*.test.ts')
+                  BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | xargs -I {} find {} -type f)
+                  echo "BENCH_FILES=$BENCH_FILES" >> $GITHUB_ENV
+
+            - name: Run benchmarks
+              if: env.BENCH_FILES != ''
+              run: pnpm vitest bench $BENCH_FILES
+              env:
+                  BENCH_FILES: ${{ env.BENCH_FILES }}
 
             - name: Convert benchmark results to markdown
+              if: env.BENCH_FILES != ''
               run: |
                   node ./scripts/benchmark-to-md.mjs benchmark-result.json ${{ github.sha }} > benchmark-results.md
 
             - name: Create PR comment
+              if: env.BENCH_FILES != ''
               uses: actions/github-script@v6
               with:
                   script: |

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -58,7 +58,7 @@ jobs:
             - name: Merge all modified bench files
               id: merge_bench_files
               run: |
-                  BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq)
+                  BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
                   echo "BENCH_FILES=$BENCH_FILES" >> $GITHUB_ENV
 
             - name: Run benchmarks

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -24,6 +24,9 @@ jobs:
               with:
                   ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
+            - name: Fetch base branch
+              run: git fetch origin $GITHUB_BASE_REF
+
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -42,23 +42,29 @@ jobs:
               id: modified_files
               run: |
                   MODIFIED=$(git diff --name-only origin/$GITHUB_BASE_REF -- 'src/*.ts' ':!src/internal/*.ts' ':!src/*.test.ts')
-                  SRC_BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | xargs -I {} find {} -type f)
+                  SRC_BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
+                    if [ -f "$file" ]; then
+                      echo "$file"
+                    fi
+                  done | xargs echo)
                   echo "SRC_BENCH_FILES=$SRC_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Find modified internal files and affected utilities
               id: modified_internal_files
               run: |
-                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF \
-                    | sed -e 's/\.ts$/.bench.ts/' \
-                    | xargs -I {} find {} -type f \
-                    | xargs echo)
+                  INTERNAL_MODIFIED=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF)
+                  INTERNAL_BENCH_FILES=$(echo "$INTERNAL_MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
+                    if [ -f "$file" ]; then
+                      echo "$file"
+                    fi
+                  done | xargs echo)
 
                   echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Merge all modified bench files
               id: merge_bench_files
               run: |
-                  BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
+                  BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq | xargs echo)
                   echo "BENCH_FILES=$BENCH_FILES" >> $GITHUB_ENV
 
             - name: Run benchmarks

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -44,12 +44,6 @@ jobs:
                   MODIFIED=$(git diff --name-only origin/$GITHUB_BASE_REF -- 'src/*.ts' ':!src/internal/*.ts' ':!src/*.test.ts')
                   SRC_BENCH_FILES=$(echo "$MODIFIED" | tr '\n' ' ')
 
-                  # SRC_BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
-                  #   if [ -f "$file" ]; then
-                  #     echo "$file"
-                  #   fi
-                  # done | xargs echo)
-
                   echo "SRC_BENCH_FILES=$SRC_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Find modified internal files and affected utilities
@@ -58,20 +52,12 @@ jobs:
                   INTERNAL_MODIFIED=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF)
                   INTERNAL_BENCH_FILES=$(echo "$INTERNAL_MODIFIED" | tr '\n' ' ')
 
-                  # INTERNAL_BENCH_FILES=$(echo "$INTERNAL_MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
-                  #   if [ -f "$file" ]; then
-                  #     echo "$file"
-                  #   fi
-                  # done | xargs echo)
-
                   echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Merge all modified bench files
               id: merge_bench_files
               run: |
                   ALL_FILES=$(echo -e "$SRC_BENCH_FILES\n$INTERNAL_BENCH_FILES")
-
-                  # BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq | xargs echo)
 
                   BENCH_FILES=$(echo "$ALL_FILES" | tr ' ' '\n' | while read file; do
                     # .bench.ts 변경은 그대로 사용

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Find modified internal files and affected utilities
               id: modified_internal_files
               run: |
-                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF | sed -e 's/\.ts$/.bench.ts/')
+                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF | sed -e 's/\.ts$/.bench.ts/' | xargs -I {} find {} -type f)
 
                   echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
 

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -42,29 +42,54 @@ jobs:
               id: modified_files
               run: |
                   MODIFIED=$(git diff --name-only origin/$GITHUB_BASE_REF -- 'src/*.ts' ':!src/internal/*.ts' ':!src/*.test.ts')
-                  SRC_BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
-                    if [ -f "$file" ]; then
-                      echo "$file"
-                    fi
-                  done | xargs echo)
+                  SRC_BENCH_FILES=$(echo "$MODIFIED" | tr '\n' ' ')
+
+                  # SRC_BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
+                  #   if [ -f "$file" ]; then
+                  #     echo "$file"
+                  #   fi
+                  # done | xargs echo)
+
                   echo "SRC_BENCH_FILES=$SRC_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Find modified internal files and affected utilities
               id: modified_internal_files
               run: |
                   INTERNAL_MODIFIED=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF)
-                  INTERNAL_BENCH_FILES=$(echo "$INTERNAL_MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
-                    if [ -f "$file" ]; then
-                      echo "$file"
-                    fi
-                  done | xargs echo)
+                  INTERNAL_BENCH_FILES=$(echo "$INTERNAL_MODIFIED" | tr '\n' ' ')
+
+                  # INTERNAL_BENCH_FILES=$(echo "$INTERNAL_MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | while read file; do
+                  #   if [ -f "$file" ]; then
+                  #     echo "$file"
+                  #   fi
+                  # done | xargs echo)
 
                   echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Merge all modified bench files
               id: merge_bench_files
               run: |
-                  BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq | xargs echo)
+                  ALL_FILES=$(echo -e "$SRC_BENCH_FILES\n$INTERNAL_BENCH_FILES")
+
+                  # BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq | xargs echo)
+
+                  BENCH_FILES=$(echo "$ALL_FILES" | tr ' ' '\n' | while read file; do
+                    # .bench.ts 변경은 그대로 사용
+                    if [[ "$file" == *.bench.ts ]]; then
+                      # 파일이 존재하는지 확인
+                      if [ -f "$file" ]; then
+                        echo "$file"
+                      fi
+                    # .ts -> .bench.ts로 변경
+                    else
+                      BENCH_FILE="${file%.ts}.bench.ts"
+                      # 파일이 존재하는지 확인
+                      if [ -f "$BENCH_FILE" ]; then
+                        echo "$BENCH_FILE"
+                      fi
+                    fi
+                  done | sort | uniq | tr '\n' ' ')
+
                   echo "BENCH_FILES=$BENCH_FILES" >> $GITHUB_ENV
 
             - name: Run benchmarks

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -39,7 +39,20 @@ jobs:
               id: modified_files
               run: |
                   MODIFIED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} -- 'src/**/*.ts' ':!src/**/*.test.ts')
-                  BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | xargs -I {} find {} -type f)
+                  SRC_BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | xargs -I {} find {} -type f)
+                  echo "SRC_BENCH_FILES=$SRC_BENCH_FILES" >> $GITHUB_ENV
+
+            - name: Find modified internal files and affected utilities
+              id: modified_internal_files
+              run: |
+                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs ${{ github.event.pull_request.base.ref }} | sed -e 's/\.ts$/.bench.ts/')
+
+                  echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
+
+            - name: Merge all modified bench files
+              id: merge_bench_files
+              run: |
+                  BENCH_FILES=$(echo "$SRC_BENCH_FILES $INTERNAL_BENCH_FILES" | tr ' ' '\n' | sort | uniq)
                   echo "BENCH_FILES=$BENCH_FILES" >> $GITHUB_ENV
 
             - name: Run benchmarks

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -38,14 +38,14 @@ jobs:
             - name: Identify modified utility files
               id: modified_files
               run: |
-                  MODIFIED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} -- 'src/**/*.ts' ':!src/**/*.test.ts')
+                  MODIFIED=$(git diff --name-only origin/$GITHUB_BASE_REF -- 'src/*.ts' ':!src/internal/*.ts' ':!src/*.test.ts')
                   SRC_BENCH_FILES=$(echo "$MODIFIED" | sed -e 's/\.ts$/.bench.ts/' | xargs -I {} find {} -type f)
                   echo "SRC_BENCH_FILES=$SRC_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Find modified internal files and affected utilities
               id: modified_internal_files
               run: |
-                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs ${{ github.event.pull_request.base.ref }} | sed -e 's/\.ts$/.bench.ts/')
+                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF | sed -e 's/\.ts$/.bench.ts/')
 
                   echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
 

--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -48,7 +48,10 @@ jobs:
             - name: Find modified internal files and affected utilities
               id: modified_internal_files
               run: |
-                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF | sed -e 's/\.ts$/.bench.ts/' | xargs -I {} find {} -type f)
+                  INTERNAL_BENCH_FILES=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF \
+                    | sed -e 's/\.ts$/.bench.ts/' \
+                    | xargs -I {} find {} -type f \
+                    | xargs echo)
 
                   echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
 

--- a/scripts/find-importing-files.mjs
+++ b/scripts/find-importing-files.mjs
@@ -65,6 +65,6 @@ const [, , commitId = 'main'] = process.argv
     const importingFiles = findImportingFiles(modifiedInternalFiles, allFiles)
 
     if (importingFiles.length > 0) {
-        console.log(importingFiles.map((importingFile) => path.relative(rootDir, importingFile)))
+        console.log(importingFiles.map((importingFile) => path.relative(rootDir, importingFile)).join('\n'))
     }
 })()

--- a/scripts/find-importing-files.mjs
+++ b/scripts/find-importing-files.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import {execSync} from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+function isTestFile(filePath) {
+    return filePath.endsWith('.bench.ts') || filePath.endsWith('.test.ts')
+}
+
+function getAllFiles(dir, fileList = []) {
+    const files = fs.readdirSync(dir)
+    files.forEach((file) => {
+        const filePath = path.join(dir, file)
+        if (filePath.endsWith('.ts') && !isTestFile(filePath)) {
+            fileList.push(filePath)
+        }
+    })
+    return fileList
+}
+
+function getModifiedInternalFiles(commitId) {
+    const output = execSync(`git diff --name-only HEAD origin/${commitId} -- src/internal/**/*.ts`, {
+        encoding: 'utf8',
+    })
+    return output
+        .split('\n')
+        .map((file) => file.trim())
+        .filter(Boolean)
+}
+
+function findImportingFiles(modifiedInternalFiles, allFiles) {
+    const result = new Set()
+
+    modifiedInternalFiles.forEach((internalFile) => {
+        allFiles.forEach((file) => {
+            const content = fs.readFileSync(file, 'utf8')
+            const relativePath = './' + path.relative(path.dirname(file), internalFile).replace(/\\/g, '/')
+            if (content.includes(`import`) && content.includes(relativePath)) {
+                result.add(file)
+            }
+        })
+    })
+
+    return [...result]
+}
+
+const [, , commitId = 'main'] = process.argv
+
+;(async () => {
+    const srcDir = path.resolve('src')
+    const allFiles = getAllFiles(srcDir)
+    const modifiedInternalFiles = getModifiedInternalFiles(commitId)
+
+    if (modifiedInternalFiles.length === 0) {
+        console.log('No modified internal files.')
+        process.exit(0)
+    }
+
+    console.log('Modified internal files:', modifiedInternalFiles)
+
+    const importingFiles = findImportingFiles(modifiedInternalFiles, allFiles)
+
+    if (importingFiles.length === 0) {
+        console.log('No files importing modified internal files.')
+    } else {
+        console.log('Files importing modified internal files:', importingFiles)
+    }
+})()

--- a/src/repeat.test.ts
+++ b/src/repeat.test.ts
@@ -3,6 +3,9 @@ import {describe, it, expect} from 'vitest'
 
 import {repeat} from './repeat'
 
+// eslint-disable-next-line no-console
+console.log(`일단 수정 갈겨`)
+
 describe('repeat', () => {
     it.concurrent.each([
         ['*', 3],


### PR DESCRIPTION
## This resolves #142

### Scenarios

1. 벤치마크 파일이 존재하는 파일을 수정 `repeat` : `repeat.bench` 실행
2. 벤치마크 파일이 존재하지 않는 파일을 수정 `isObject` : `isObject.bench`는 없으므로 미실행
3. `internal` 경로를 수정 `src/internal/baseIteratee` : `baseIteratee`를 import하는 `findLastIndex.bench`, `findIndex.bench` 실행
4. 벤치마크 파일을 직접 수정 `repeat` : `repeat.bench` 실행
5. 테스트 파일만 수정 : 미실행