### PR TITLE
🚀 times

### DIFF
--- a/.changeset/moody-drinks-search.md
+++ b/.changeset/moody-drinks-search.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/hidash": patch
+---
+
+🚀 times
+
+PR: [🚀 times](https://github.com/NaverPayDev/hidash/pull/178)

--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,7 @@ const moduleMap = {
     sum: './src/sum.ts',
     sumBy: './src/sumBy.ts',
     throttle: './src/throttle.ts',
+    times: './src/times.ts',
     toNumber: './src/toNumber.ts',
     toPairs: './src/toPairs.ts',
     toString: './src/toString.ts',

--- a/package.json
+++ b/package.json
@@ -520,6 +520,16 @@
                 "default": "./throttle.js"
             }
         },
+        "./times": {
+            "import": {
+                "types": "./times.d.mts",
+                "default": "./times.mjs"
+            },
+            "require": {
+                "types": "./times.d.ts",
+                "default": "./times.js"
+            }
+        },
         "./toNumber": {
             "import": {
                 "types": "./toNumber.d.mts",

--- a/src/times.test.ts
+++ b/src/times.test.ts
@@ -1,0 +1,47 @@
+import _times from 'lodash/times'
+import {describe, it, expect} from 'vitest'
+
+import {times} from './times'
+
+describe('times function', () => {
+    it('matches lodash for basic cases', () => {
+        const testCases = [0, 1, 2, 5, 10, 50]
+        testCases.forEach((n) => {
+            expect(times(n)).toStrictEqual(_times(n))
+            expect(times(n, (i) => i * 2)).toStrictEqual(_times(n, (i) => i * 2))
+            expect(times(n, (i) => `str-${i}`)).toStrictEqual(_times(n, (i) => `str-${i}`))
+        })
+    })
+
+    it('returns empty array for invalid input', () => {
+        const invalidCases = [-1, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1, 1.5]
+        invalidCases.forEach((n) => {
+            expect(times(n)).toStrictEqual([])
+        })
+    })
+
+    it('handles large but valid values', () => {
+        const largeN = 10000
+        const arr = times(largeN, (i) => i)
+        expect(arr.length).toBe(largeN)
+        expect(arr[largeN - 1]).toBe(largeN - 1)
+    })
+
+    it('uses identity as default iteratee', () => {
+        expect(times(3)).toStrictEqual([0, 1, 2])
+        expect(_times(3)).toStrictEqual([0, 1, 2])
+    })
+
+    it('handles custom iteratee that returns objects', () => {
+        const n = 5
+        const arr = times(n, (i) => ({index: i, val: i * 10}))
+        expect(arr).toHaveLength(5)
+        expect(arr[0]).toEqual({index: 0, val: 0})
+        expect(arr[4]).toEqual({index: 4, val: 40})
+    })
+
+    it('handles empty arrays correctly', () => {
+        expect(times(0)).toStrictEqual([])
+        expect(times(-100)).toStrictEqual([])
+    })
+})

--- a/src/times.ts
+++ b/src/times.ts
@@ -1,0 +1,24 @@
+export function times(n: number): number[]
+export function times<TResult>(n: number, iteratee: (num: number) => TResult): TResult[]
+export function times<TResult>(n: number, iteratee?: (num: number) => TResult): (number | TResult)[] {
+    const nTimes = Math.floor(Number(n))
+    if (n < 1) {
+        return []
+    }
+
+    const result = new Array(nTimes)
+
+    if (iteratee) {
+        for (let i = 0; i < nTimes; i++) {
+            result[i] = iteratee(i)
+        }
+    } else {
+        for (let i = 0; i < nTimes; i++) {
+            result[i] = i
+        }
+    }
+
+    return result
+}
+
+export default times

--- a/src/times.ts
+++ b/src/times.ts
@@ -1,11 +1,11 @@
 export function times(n: number): number[]
 export function times<TResult>(n: number, iteratee: (num: number) => TResult): TResult[]
 export function times<TResult>(n: number, iteratee?: (num: number) => TResult): (number | TResult)[] {
-    const nTimes = Math.floor(Number(n))
-    if (n < 1) {
+    if (!Number.isInteger(n) || n < 1 || n >= Number.MAX_SAFE_INTEGER) {
         return []
     }
 
+    const nTimes = n
     const result = new Array(nTimes)
 
     if (iteratee) {


### PR DESCRIPTION
## This resolves #99 

`times` codes are almost the same as `lodash/times`, so I didn't write a benchmark.