### PR TITLE
🔧PropertyPath 로 분리

### DIFF
--- a/.changeset/good-knives-write.md
+++ b/.changeset/good-knives-write.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/hidash": patch
+---
+
+🔧 `omit` 내부 타입을 PropertyPath 로 분리
+
+PR: [🔧PropertyPath 로 분리](https://github.com/NaverPayDev/hidash/pull/193)

--- a/src/has.ts
+++ b/src/has.ts
@@ -1,4 +1,5 @@
-type PropertyPath = string | string[]
+import {Many, PropertyPath} from './internal/types'
+import isArray from './isArray'
 
 const reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/
 const reIsPlainProp = /^\w*$/
@@ -13,11 +14,14 @@ function isKey(value: PropertyPath, object: unknown): boolean {
     return reIsPlainProp.test(value) || !reIsDeepProp.test(value) || (object != null && value in Object(object))
 }
 
-function castPath(value: PropertyPath): string[] {
+function castPath(value: Many<string | number | symbol>): string[] {
     if (Array.isArray(value)) {
-        return [...value]
+        return value.map(String)
     }
-    return value.split('.')
+    if (typeof value === 'string') {
+        return value.split('.')
+    }
+    return [String(value)]
 }
 
 function hasPath(object: unknown, path: PropertyPath): boolean {
@@ -67,7 +71,7 @@ export function has(object: unknown, path: PropertyPath): boolean {
         if (!path.includes('.')) {
             return object != null && typeof object === 'object' && Object.prototype.hasOwnProperty.call(object, path)
         }
-    } else if (!path.every((segment) => typeof segment === 'string')) {
+    } else if (isArray(path) && !path.every((segment) => typeof segment === 'string')) {
         return false
     }
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -6,3 +6,5 @@ export type Dictionary<T> = Record<string, T>
 export type NumericDictionary<T> = Record<number, T>
 export type AnyKindOfDictionary<T> = Dictionary<T> | NumericDictionary<T>
 export type Many<T> = T | Many<T>[]
+
+export type PropertyPath = Many<string | number | symbol>

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,4 +1,4 @@
-type PropertyPath = string | number | symbol | readonly (string | number | symbol)[]
+import {PropertyPath} from './internal/types'
 
 export function omit<T extends object>(object: T | null | undefined, ...paths: PropertyPath[]): T {
     if (object == null) {


### PR DESCRIPTION
#89

- PropertyPath 를 별도 타입으로 분리
- lodash 와 동일하게 타입을 더 좁힙니다.