### PR TITLE
fix: Preserve class prototype chain in cloneDeep function

### DIFF
--- a/src/cloneDeep.test.ts
+++ b/src/cloneDeep.test.ts
@@ -68,4 +68,18 @@ describe('cloneDeep function comparison with lodash', () => {
             expect(cloneDeep(value)).toStrictEqual(_cloneDeep(value))
         })
     })
+
+    it('handles class instances', () => {
+        class User {
+            name: string
+            constructor(name: string) {
+                this.name = name
+            }
+        }
+        const user = new User('Alice')
+        const clonedUser = cloneDeep(user)
+        expect(clonedUser).toStrictEqual(_cloneDeep(user))
+        expect(clonedUser).not.toBe(user)
+        expect(clonedUser.constructor).toBe(User)
+    })
 })

--- a/src/cloneDeep.ts
+++ b/src/cloneDeep.ts
@@ -46,7 +46,8 @@ export function cloneDeep<T>(value: T): T {
         }
 
         if (type === '[object Object]') {
-            const result: Record<string, unknown> = {}
+            const proto = Object.getPrototypeOf(v)
+            const result = Object.create(proto)
             for (const key in v) {
                 if (Object.prototype.hasOwnProperty.call(v, key)) {
                     result[key] = deepClone((v as Record<string, unknown>)[key])


### PR DESCRIPTION
## This resolves 

### Description
This PR fixes an issue where the `cloneDeep` function was not properly preserving the prototype chain when cloning class instances. The previous implementation treated class instances as plain objects, which resulted in losing the class type information during cloning.

### Changes Made
- Modified the object cloning logic to preserve prototype chain using `Object.getPrototypeOf` and `Object.create`
- Added comprehensive test cases to verify class instance cloning behavior
- Ensured compatibility with lodash's `cloneDeep` implementation

### Test Cases
Added a new test suite that verifies:
- Proper cloning of class instances
- Preservation of constructor and prototype chain
- Consistency with lodash's behavior

### Example
```typescript
class User {
    name: string
    constructor(name: string) {
        this.name = name
    }
}
const user = new User('Alice')
const clonedUser = cloneDeep(user)

// Now correctly preserves the class type
console.log(clonedUser instanceof User) // true
console.log(clonedUser.constructor === User) // true
