### PR TITLE
feat: Add noop function

### DIFF
--- a/src/cloneDeep.bench.ts
+++ b/src/cloneDeep.bench.ts
@@ -2,6 +2,7 @@ import _cloneDeep from 'lodash/cloneDeep'
 import {bench, describe} from 'vitest'
 
 import {cloneDeep} from './cloneDeep'
+import {noop} from './internal/noop'
 
 const testCases: unknown[] = [
     // Primitive values
@@ -77,7 +78,7 @@ const testCases: unknown[] = [
             ]),
             set: new Set([1, 2, 3]),
         },
-        func: () => {},
+        func: noop,
         symbol: Symbol('test'),
     },
     // Large deeply nested structure

--- a/src/cloneDeep.test.ts
+++ b/src/cloneDeep.test.ts
@@ -2,6 +2,7 @@ import _cloneDeep from 'lodash/cloneDeep'
 import {describe, it, expect} from 'vitest'
 
 import {cloneDeep} from './cloneDeep'
+import {noop} from './internal/noop'
 
 describe('cloneDeep function comparison with lodash', () => {
     it('handles primitive values', () => {
@@ -63,7 +64,7 @@ describe('cloneDeep function comparison with lodash', () => {
     })
 
     it('handles unsupported types', () => {
-        const testCases = [() => {}, new WeakMap(), new WeakSet()]
+        const testCases = [noop, new WeakMap(), new WeakSet()]
         testCases.forEach((value) => {
             expect(cloneDeep(value)).toStrictEqual(_cloneDeep(value))
         })

--- a/src/internal/noop.test.ts
+++ b/src/internal/noop.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from 'vitest'
+
+import {noop} from './noop'
+
+describe('noop', () => {
+    it('should be a function', () => {
+        expect(noop instanceof Function).toBeTruthy()
+    })
+
+    it('should return undefined', () => {
+        const result = noop()
+
+        expect(result).toBeUndefined()
+    })
+})

--- a/src/internal/noop.ts
+++ b/src/internal/noop.ts
@@ -1,0 +1,1 @@
+export function noop() {}

--- a/src/isEmpty.test.ts
+++ b/src/isEmpty.test.ts
@@ -1,6 +1,7 @@
 import _isEmpty from 'lodash/isEmpty'
 import {describe, test, expect} from 'vitest'
 
+import {noop} from './internal/noop'
 import isEmpty from './isEmpty'
 
 describe('isEmpty function', () => {
@@ -61,7 +62,7 @@ describe('isEmpty function', () => {
     })
 
     test('should return true for a function', () => {
-        const fn = () => {}
+        const fn = noop
         expect(isEmpty(fn)).toBe(true)
         expect(isEmpty(fn)).toBe(_isEmpty(fn))
     })

--- a/src/isError.test.ts
+++ b/src/isError.test.ts
@@ -1,6 +1,7 @@
 import _isError from 'lodash/isError'
 import {describe, it, expect} from 'vitest'
 
+import {noop} from './internal/noop'
 import isError from './isError'
 
 describe('isError', () => {
@@ -64,7 +65,7 @@ describe('isError', () => {
     it('should match lodash for proxy-wrapped values', () => {
         const proxyError = new Proxy(new Error('test'), {})
         const proxyObject = new Proxy({}, {})
-        const proxyFunction = new Proxy(() => {}, {})
+        const proxyFunction = new Proxy(noop, {})
 
         expect(isError(proxyError)).toBe(_isError(proxyError))
         expect(isError(proxyObject)).toBe(_isError(proxyObject))

--- a/src/isFunction.test.ts
+++ b/src/isFunction.test.ts
@@ -1,11 +1,12 @@
 import {describe, it, expect} from 'vitest'
 
+import {noop} from './internal/noop'
 import isFunction from './isFunction'
 
 describe('isFunction', () => {
     it('should return true for normal functions', () => {
         expect(isFunction(function () {})).toBe(true)
-        expect(isFunction(() => {})).toBe(true)
+        expect(isFunction(noop)).toBe(true)
     })
 
     it('should return true for async functions', () => {
@@ -19,7 +20,7 @@ describe('isFunction', () => {
     })
 
     it('should return true for Proxy-wrapped functions', () => {
-        const proxyFunc = new Proxy(() => {}, {})
+        const proxyFunc = new Proxy(noop, {})
         expect(isFunction(proxyFunc)).toBe(true)
     })
 

--- a/src/isPlainObject.test.ts
+++ b/src/isPlainObject.test.ts
@@ -1,6 +1,7 @@
 import _isPlainObject from 'lodash/isPlainObject'
 import {describe, test, expect} from 'vitest'
 
+import {noop} from './internal/noop'
 import {isPlainObject} from './isPlainObject'
 
 describe('isPlainObject function', () => {
@@ -53,8 +54,8 @@ describe('isPlainObject function', () => {
         expect(isPlainObject(Function)).toBe(false)
         expect(isPlainObject(Function)).toBe(_isPlainObject(Function))
 
-        expect(isPlainObject(() => {})).toBe(false)
-        expect(isPlainObject(() => {})).toBe(_isPlainObject(() => {}))
+        expect(isPlainObject(noop)).toBe(false)
+        expect(isPlainObject(noop)).toBe(_isPlainObject(noop))
 
         expect(isPlainObject(class {})).toBe(false)
         expect(isPlainObject(class {})).toBe(_isPlainObject(class {}))

--- a/src/memoize.test.ts
+++ b/src/memoize.test.ts
@@ -1,5 +1,6 @@
 import {describe, test, expect, vi} from 'vitest'
 
+import {noop} from './internal/noop'
 import memoize from './memoize'
 
 describe('memoize function', () => {
@@ -112,7 +113,7 @@ describe('memoize function', () => {
 
         // resolver가 함수가 아닐 때 TypeError를 던지는지 확인
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect(() => memoize(() => {}, 'not a function' as any)).toThrow(TypeError)
+        expect(() => memoize(noop, 'not a function' as any)).toThrow(TypeError)
     })
 
     test('handles functions with no arguments', () => {

--- a/src/shuffle.test.ts
+++ b/src/shuffle.test.ts
@@ -1,6 +1,7 @@
 import _shuffle from 'lodash/shuffle'
 import {describe, test, expect} from 'vitest'
 
+import {noop} from './internal/noop'
 import shuffle from './shuffle'
 
 describe('shuffle function', () => {
@@ -122,7 +123,7 @@ describe('shuffle function', () => {
     })
 
     test('returns empty array for functions', () => {
-        expect(shuffle(() => {})).toEqual([])
+        expect(shuffle(noop)).toEqual([])
         expect(shuffle(function () {})).toEqual([])
     })
 

--- a/src/size.test.ts
+++ b/src/size.test.ts
@@ -1,6 +1,7 @@
 import _size from 'lodash/size'
 import {describe, test, expect} from 'vitest'
 
+import {noop} from './internal/noop'
 import size from './size'
 
 describe('size function', () => {
@@ -82,7 +83,7 @@ describe('size function', () => {
     })
 
     test('returns 0 for functions', () => {
-        const arrowFn = () => {}
+        const arrowFn = noop
         expect(size(arrowFn)).toBe(0)
         expect(size(arrowFn)).toBe(_size(arrowFn))
 

--- a/src/toPairs.test.ts
+++ b/src/toPairs.test.ts
@@ -1,6 +1,7 @@
 import _toPairs from 'lodash/toPairs'
 import {describe, test, expect} from 'vitest'
 
+import {noop} from './internal/noop'
 import {toPairs} from './toPairs'
 
 describe('toPairs', () => {
@@ -75,13 +76,13 @@ describe('toPairs', () => {
         expect(toPairs(true)).toEqual([])
         expect(toPairs(Symbol(1))).toEqual([])
         expect(toPairs(new Error())).toEqual([])
-        expect(toPairs(() => {})).toEqual([])
+        expect(toPairs(noop)).toEqual([])
 
         expect(toPairs(123)).toEqual(_toPairs(123))
         expect(toPairs(true)).toEqual(_toPairs(true))
         expect(toPairs(Symbol(1))).toEqual(_toPairs(Symbol(1)))
         expect(toPairs(new Error())).toEqual(_toPairs(new Error()))
-        expect(toPairs(() => {})).toEqual(_toPairs(() => {}))
+        expect(toPairs(noop)).toEqual(_toPairs(noop))
     })
 
     test('should handle empty inputs gracefully', () => {


### PR DESCRIPTION
## This resolves

### Description

This PR adds a `noop` utility function that implements the existing `Noop` type. The function is a common utility that can be used wherever an empty function callback is needed, improving code readability and reusability.

### Changes
- Add `noop` utility function
- Apply `noop` function in test files instead of empty arrow functions
- Add test cases for `noop` function
