### PR TITLE
[POC] Add comment for external PRs to request manual benchmark execution

### DIFF
--- a/.github/workflows/benchmark-to-comment.yml
+++ b/.github/workflows/benchmark-to-comment.yml
@@ -10,7 +10,7 @@ on:
         inputs:
             pr_number:
                 description: 'PR number to run benchmark on'
-                required: false
+                required: true
                 type: string
 
 permissions:
@@ -38,7 +38,40 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Check if PR is from a fork
+              id: check_fork
+              run: |
+                  if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+                    echo "IS_FORK=true" >> $GITHUB_ENV
+                  else
+                    echo "IS_FORK=false" >> $GITHUB_ENV
+                  fi
+
+            - name: Post comment for external PRs
+              if: env.IS_FORK == 'true'
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const prNumber = context.payload.pull_request.number;
+
+                      const message = `
+                      ⚠️ **Automated benchmark tests are not run for external PRs.**
+
+                      If you want to run benchmarks for this PR, a maintainer can trigger it manually by:
+                      1. Going to **Actions** tab.
+                      2. Selecting **Benchmark Comment on PR** workflow.
+                      3. Running the workflow with **PR number: ${prNumber}**.
+
+                      _This is a security measure to prevent unauthorized code execution from forked repositories._`;
+
+                      await github.rest.issues.createComment({
+                        ...context.repo,
+                        issue_number: prNumber,
+                        body: message
+                      });
+
             - name: Identify modified utility files
+              if: env.IS_FORK == 'false'
               id: modified_files
               run: |
                   MODIFIED=$(git diff --name-only origin/$GITHUB_BASE_REF -- 'src/*.ts' ':!src/internal/*.ts' ':!src/*.test.ts')
@@ -47,6 +80,7 @@ jobs:
                   echo "SRC_BENCH_FILES=$SRC_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Find modified internal files and affected utilities
+              if: env.IS_FORK == 'false'
               id: modified_internal_files
               run: |
                   INTERNAL_MODIFIED=$(node ./scripts/find-importing-files.mjs $GITHUB_BASE_REF)
@@ -55,21 +89,18 @@ jobs:
                   echo "INTERNAL_BENCH_FILES=$INTERNAL_BENCH_FILES" >> $GITHUB_ENV
 
             - name: Merge all modified bench files
+              if: env.IS_FORK == 'false'
               id: merge_bench_files
               run: |
                   ALL_FILES=$(echo -e "$SRC_BENCH_FILES\n$INTERNAL_BENCH_FILES")
 
                   BENCH_FILES=$(echo "$ALL_FILES" | tr ' ' '\n' | while read file; do
-                    # .bench.ts 변경은 그대로 사용
                     if [[ "$file" == *.bench.ts ]]; then
-                      # 파일이 존재하는지 확인
                       if [ -f "$file" ]; then
                         echo "$file"
                       fi
-                    # .ts -> .bench.ts로 변경
                     else
                       BENCH_FILE="${file%.ts}.bench.ts"
-                      # 파일이 존재하는지 확인
                       if [ -f "$BENCH_FILE" ]; then
                         echo "$BENCH_FILE"
                       fi
@@ -79,18 +110,18 @@ jobs:
                   echo "BENCH_FILES=$BENCH_FILES" >> $GITHUB_ENV
 
             - name: Run benchmarks
-              if: env.BENCH_FILES != ''
+              if: env.BENCH_FILES != '' && env.IS_FORK == 'false'
               run: pnpm vitest bench $BENCH_FILES
               env:
                   BENCH_FILES: ${{ env.BENCH_FILES }}
 
             - name: Convert benchmark results to markdown
-              if: env.BENCH_FILES != ''
+              if: env.BENCH_FILES != '' && env.IS_FORK == 'false'
               run: |
                   node ./scripts/benchmark-to-md.mjs benchmark-result.json ${{ github.sha }} > benchmark-results.md
 
             - name: Create PR comment
-              if: env.BENCH_FILES != ''
+              if: env.BENCH_FILES != '' && env.IS_FORK == 'false'
               uses: actions/github-script@v6
               with:
                   script: |
@@ -102,15 +133,7 @@ jobs:
                         process.env.GITHUB_REPOSITORY + '/actions/runs/' +
                         process.env.GITHUB_RUN_ID + ')*';
 
-                      let prNumber;
-                      if (context.eventName === 'pull_request') {
-                        prNumber = context.payload.pull_request.number;
-                      } else if (context.payload.inputs?.pr_number) {
-                        prNumber = parseInt(context.payload.inputs.pr_number, 10);
-                      } else {
-                        console.log('No PR number provided for workflow_dispatch event');
-                        return;
-                      }
+                      let prNumber = context.payload.pull_request.number;
 
                       const { data: comments } = await github.rest.issues.listComments({
                         ...context.repo,


### PR DESCRIPTION
#206 

### Summary

This PR updates the benchmark workflow to handle external pull requests more securely.  
For PRs from forked repositories, the benchmark will no longer run automatically due to security restrictions. Instead, a comment is added to the PR, informing the contributor that benchmarks must be triggered manually by a maintainer.

### Changes

- Added a check to determine if the PR is from a fork.
- If the PR is from a fork:
  - The benchmark workflow does **not** execute automatically.
  - A comment is posted on the PR explaining how to manually trigger the benchmark using `workflow_dispatch`.
- Internal branch PRs remain unaffected and continue to run benchmarks automatically.

### Why?

GitHub restricts permissions for workflows triggered by external PRs to prevent unauthorized code execution. This update ensures security while allowing maintainers to run benchmarks when necessary.

### How to Trigger a Benchmark for an External PR

1. Go to the **Actions** tab.
2. Select the **Benchmark Comment on PR** workflow.
3. Manually run the workflow by entering the PR number.

This ensures that benchmarks can still be run for external contributions when needed, without introducing security risks.
