### PR TITLE
🔧 fix event target

### DIFF
--- a/.github/workflows/detect-changed-packages.yml
+++ b/.github/workflows/detect-changed-packages.yml
@@ -1,7 +1,7 @@
 name: detect changed packages
 
 on:
-    pull_request:
+    pull_request_target:
         branches: ['**']
         types: [opened, reopened, labeled, unlabeled, synchronize]
 

--- a/.github/workflows/validate-utils-registration.yml
+++ b/.github/workflows/validate-utils-registration.yml
@@ -7,7 +7,6 @@ on:
             - 'index.ts'
             - 'package.json'
             - 'scripts/generate-utils.mjs'
-    workflow_dispatch:
 
 jobs:
     check-utils:

--- a/.github/workflows/validate-utils-registration.yml
+++ b/.github/workflows/validate-utils-registration.yml
@@ -1,7 +1,7 @@
 name: Validate Utils Registration
 
 on:
-    pull_request:
+    pull_request_target:
         paths:
             - 'src/**'
             - 'index.ts'


### PR DESCRIPTION
## This resolves #206 

fix github action evnet type from 'pull_request' to 'pull_request_target'
see: https://docs.github.com/ko/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target