### PR TITLE
Fix vite.config.mts

### DIFF
--- a/.changeset/fair-teeth-refuse.md
+++ b/.changeset/fair-teeth-refuse.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/hidash": patch
+---
+
+Fix vite.config.mts
+
+PR: [Fix vite.config.mts](https://github.com/NaverPayDev/hidash/pull/221)

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -6,7 +6,7 @@ export default createViteConfig({
     cwd: '.',
     formats: ['cjs', 'es'],
     entry: moduleMap,
-    allowedPolyfills: [
+    ignoredPolyfills: [
         'es.array.push', // https://bugs.chromium.org/p/v8/issues/detail?id=12681
         'es.array.includes', // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
         'es.array.reduce', // https://issues.chromium.org/issues/40672866


### PR DESCRIPTION
 ## This resolves <!-- add issue number -->

There is polyfill injection bug in `uniq.(mjs | js)`

```js
// uniq.mjs
import s from "core-js-pure/features/instance/push.js";
```

When users use `uniq` function in their code, this error occured because hidash does not have `core-js-pure` as deps:

```
Error: Cannot find module 'core-js-pure/features/instance/push.js'
``` 

### Fix build config: Not 'allow', intend to 'exclude'