### PR TITLE
Fix Issue #222: Handle null/undefined in `merge` function

### DIFF
--- a/.changeset/rare-cougars-see.md
+++ b/.changeset/rare-cougars-see.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/hidash": patch
+---
+
+Fix Issue #222: Handle null/undefined in `merge` function
+
+PR: [Fix Issue #222: Handle null/undefined in `merge` function](https://github.com/NaverPayDev/hidash/pull/223)

--- a/src/merge.test.ts
+++ b/src/merge.test.ts
@@ -174,4 +174,18 @@ describe('merge', () => {
         expect(() => merge(obj, source)).not.toThrow()
         expect(() => _merge(obj, source)).not.toThrow()
     })
+
+    it('should handle empty array', () => {
+        const emptyArr = []
+
+        const expected = _merge(emptyArr[0], ...emptyArr)
+        const result = merge(emptyArr[0], ...emptyArr)
+        expect(result).toEqual(expected)
+    })
+
+    it('should handle empty object', () => {
+        const expected = _merge({}, {})
+        const result = merge({}, {})
+        expect(result).toEqual(expected)
+    })
 })

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {DATE_TAG, REGEXP_TAG} from './internal/to-string-tags'
+import isNil from './isNil'
 import isObject from './isObject'
 
 const toString = Object.prototype.toString
@@ -91,7 +92,7 @@ export function merge<TObject extends object, TSource extends object>(
 ): TObject & TSource {
     const length = sources.length
     if (!length) {
-        return object as TObject & TSource
+        return isNil(object) ? ({} as TObject & TSource) : (object as TObject & TSource)
     }
 
     let result = object


### PR DESCRIPTION
### Description

This pull request addresses issue #222 by adding null and undefined checks to the first parameter of the `merge` function in `hidash`.  This prevents potential errors when the function is called with a null or undefined value as the first argument.

**Summary of Changes:**

*   [x] Added checks for null and undefined values in the first parameter of the `merge` function.
*   [x] Ensures that the `merge` function handles cases where the first parameter is null or undefined without returning `undefined` (same as lodash)

**Related Issue:**

*   Closes #222
