### PR TITLE
💥 Remove `PropertyName` typed IterateeShorthand

### DIFF
--- a/.changeset/bumpy-beds-chew.md
+++ b/.changeset/bumpy-beds-chew.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/hidash": minor
+---
+
+💥 Remove `PropertyName` typed IterateeShorthand
+
+PR: [💥 Remove `PropertyName` typed IterateeShorthand](https://github.com/NaverPayDev/hidash/pull/228)

--- a/src/every.test.ts
+++ b/src/every.test.ts
@@ -45,10 +45,6 @@ describe('every', () => {
         })
     })
 
-    it('should handle object arrays with property name', () => {
-        expect(every([{name: 'jj'}, {name: 'bb'}], 'name')).toBe(_every([{name: 'jj'}, {name: 'bb'}], 'name'))
-    })
-
     it('should handle empty objects', () => {
         expect(every({})).toBe(_every({}))
         expect(every({}, (v) => !!v)).toBe(_every({}, (v) => !!v))

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -117,7 +117,6 @@ describe('filter', () => {
         ]
         const predicate = (item: {details: {active: boolean}}) => item.details.active
         expect(filter(input, predicate)).toEqual(_filter(input, predicate))
-        expect(filter(input, 'details.active')).toEqual(_filter(input, 'details.active'))
     })
 
     // Edge case: Predicate is a value instead of a function

--- a/src/findIndex.bench.ts
+++ b/src/findIndex.bench.ts
@@ -22,7 +22,7 @@ const testCases = [
             {id: 3, value: 'c'},
             {id: 4, value: 'd'},
         ],
-        'value',
+        (item: {id: number; value: string}) => item.value,
     ],
     [
         [

--- a/src/findIndex.test.ts
+++ b/src/findIndex.test.ts
@@ -33,17 +33,6 @@ describe('findIndex', () => {
         expect(findIndex(nestedArray, ['a', 10])).toBe(_findIndex(nestedArray, ['a', 10]))
     })
 
-    it('should handle string shorthand predicates', () => {
-        const nestedArray = [{a: 1}, {b: 2}, {a: 3}]
-
-        expect(findIndex(nestedArray, 'a')).toBe(0)
-        expect(findIndex(nestedArray, 'b')).toBe(1)
-        expect(findIndex(nestedArray, 'c')).toBe(-1)
-        expect(findIndex(nestedArray, 'a')).toBe(_findIndex(nestedArray, 'a'))
-        expect(findIndex(nestedArray, 'b')).toBe(_findIndex(nestedArray, 'b'))
-        expect(findIndex(nestedArray, 'c')).toBe(_findIndex(nestedArray, 'c'))
-    })
-
     it('should support a fromIndex parameter (positive values)', () => {
         const array = [1, 2, 3, 4, 5]
 

--- a/src/findLastIndex.bench.ts
+++ b/src/findLastIndex.bench.ts
@@ -22,7 +22,7 @@ const testCases = [
             {id: 3, value: 'c'},
             {id: 4, value: 'd'},
         ],
-        'value',
+        (item: {id: number; value: string}) => item.value,
     ],
     [
         [

--- a/src/findLastIndex.test.ts
+++ b/src/findLastIndex.test.ts
@@ -40,21 +40,6 @@ describe('findLastIndex', () => {
         )
     })
 
-    it('should handle string predicate (key lookup)', () => {
-        const array = [{a: 1}, {a: 2}, {a: 3}]
-        expect(findLastIndex(array, 'a')).toBe(2)
-        expect(findLastIndex(array, 'a')).toBe(_findLastIndex(array, 'a'))
-
-        expect(findLastIndex(array, 'b')).toBe(-1)
-        expect(findLastIndex(array, 'b')).toBe(_findLastIndex(array, 'b'))
-    })
-
-    it('should handle arrays of objects with number as predicate (key lookup)', () => {
-        const array = [{1: 'value'}, {}, {1: 'other'}]
-        expect(findLastIndex(array, 1)).toBe(2)
-        expect(findLastIndex(array, 1)).toBe(_findLastIndex(array, 1))
-    })
-
     it('should handle array predicate ([key, value])', () => {
         const array = [{a: 1}, {a: 2}, {a: 3}]
         expect(findLastIndex(array, ['a', 2])).toBe(1)
@@ -130,9 +115,6 @@ describe('findLastIndex', () => {
 
         expect(findLastIndex([], (v) => v === 1)).toBe(-1)
         expect(findLastIndex([], (v) => v === 1)).toBe(_findLastIndex([], (v) => v === 1))
-
-        expect(findLastIndex([], 'a')).toBe(-1)
-        expect(findLastIndex([], 'a')).toBe(_findLastIndex([], 'a'))
     })
 
     it('should handle arrays with undefined or null values', () => {

--- a/src/groupBy.bench.ts
+++ b/src/groupBy.bench.ts
@@ -12,7 +12,7 @@ const basicTestCases = [
             {id: 4, category: 'C', value: 40},
             {id: 5, category: 'B', value: 50},
         ],
-        iteratee: 'category',
+        iteratee: (item: {id: number; category: string; value: number}) => item.category,
     },
     {
         data: Array.from({length: 100}, (_, i) => i),
@@ -20,7 +20,7 @@ const basicTestCases = [
     },
     {
         data: [null, undefined, {id: 1, value: 'a'}, {id: 2, value: 'b'}, null, {id: 3, value: 'a'}],
-        iteratee: 'value',
+        iteratee: (item: null | undefined | {id: number; value: string}) => item?.value,
     },
 ] as const
 
@@ -47,7 +47,7 @@ const complexTestCases = [
             category: String.fromCharCode(65 + (i % 26)), // A-Z 반복
             value: i * 10,
         })),
-        iteratee: 'category',
+        iteratee: (item: {id: number; category: string; value: number}) => item.category,
     },
 ] as const
 

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -10,25 +10,10 @@ const users = [
     {id: 4, name: 'Alice', age: 30, city: 'LA'},
 ]
 
-const objects = {
-    user1: {age: 25, name: 'John'},
-    user2: {age: 30, name: 'Jane'},
-    user3: {age: 25, name: 'Bob'},
-}
-
 describe('basic functionality', () => {
-    it('should group array by property', () => {
-        expect(groupBy(users, 'age')).toEqual(_groupBy(users, 'age'))
-        expect(groupBy(users, 'city')).toEqual(_groupBy(users, 'city'))
-    })
-
     it('should group array using iteratee function', () => {
         const iteratee = (user) => (user.age >= 30 ? 'senior' : 'junior')
         expect(groupBy(users, iteratee)).toEqual(_groupBy(users, iteratee))
-    })
-
-    it('should group object values by property', () => {
-        expect(groupBy(objects, 'age')).toEqual(_groupBy(objects, 'age'))
     })
 })
 
@@ -42,19 +27,9 @@ describe('edge cases', () => {
         expect(groupBy([])).toEqual(_groupBy([]))
         expect(groupBy({})).toEqual(_groupBy({}))
     })
-
-    it('should handle missing properties', () => {
-        const data = [{id: 1, name: 'John'}, {id: 2}, {id: 3, name: 'Bob'}]
-        expect(groupBy(data, 'name')).toEqual(_groupBy(data, 'name'))
-    })
 })
 
 describe('special values', () => {
-    it('should handle arrays with null/undefined values', () => {
-        const data = [null, undefined, {id: 1}, {id: 2}]
-        expect(groupBy(data, 'id')).toEqual(_groupBy(data, 'id'))
-    })
-
     it('should handle arrays with primitive values', () => {
         const numbers = [1.2, 2.1, 2.3]
         expect(groupBy(numbers, Math.floor)).toEqual(_groupBy(numbers, Math.floor))
@@ -86,16 +61,6 @@ describe('complex scenarios', () => {
         const iteratee = (item) => item.tags[0]
         expect(groupBy(data, iteratee)).toEqual(_groupBy(data, iteratee))
     })
-
-    it('should handle nested object paths using string notation', () => {
-        const data = [
-            {insurance: {type: 'health', value: 100}},
-            {insurance: {type: 'life', value: 200}},
-            {insurance: {type: 'health', value: 300}},
-        ]
-
-        expect(groupBy(data, 'insurance.type')).toEqual(_groupBy(data, (item) => item.insurance.type))
-    })
 })
 
 describe('performance cases', () => {
@@ -106,16 +71,11 @@ describe('performance cases', () => {
             value: Math.random(),
         }))
 
-        expect(groupBy(largeArray, 'category')).toEqual(_groupBy(largeArray, 'category'))
+        expect(groupBy(largeArray, (item) => item.category)).toEqual(_groupBy(largeArray, 'category'))
     })
 })
 
 describe('error cases', () => {
-    it('should handle invalid iteratee paths', () => {
-        expect(groupBy(users, 'nonexistent')).toEqual(_groupBy(users, 'nonexistent'))
-        expect(groupBy(users, '')).toEqual(_groupBy(users, ''))
-    })
-
     it('should handle invalid iteratee functions', () => {
         const invalidIteratee = () => {
             throw new Error('error')
@@ -138,7 +98,6 @@ describe('type safety', () => {
     ]
 
     it('should work with typed arrays', () => {
-        expect(groupBy(typedUsers, 'age')).toEqual(_groupBy(typedUsers, 'age'))
         expect(groupBy(typedUsers, (user) => (user.age >= 30 ? 'senior' : 'junior'))).toEqual(
             _groupBy(typedUsers, (user) => (user.age >= 30 ? 'senior' : 'junior')),
         )

--- a/src/internal/baseIteratee.test.ts
+++ b/src/internal/baseIteratee.test.ts
@@ -3,31 +3,6 @@ import {describe, it, expect} from 'vitest'
 import {baseIteratee} from './baseIteratee'
 
 describe('baseIteratee', () => {
-    it('should handle string property path', () => {
-        const iteratee = baseIteratee<{a: {b: {c: number}}}, number>('a.b.c')
-        const obj = {a: {b: {c: 42}}}
-        expect(iteratee(obj, 0, [])).toBe(42)
-    })
-
-    it('should handle number as property key', () => {
-        const iteratee = baseIteratee<number[], number>(2)
-        const collection: number[][] = [
-            [10, 20, 30],
-            [40, 50, 60],
-        ]
-        const value = collection[0]
-        expect(iteratee(value, 0, collection)).toBe(30)
-    })
-
-    it('should handle symbol as property key', () => {
-        const symKey = Symbol('key')
-        type ObjWithSym = Record<typeof symKey, string>
-
-        const iteratee = baseIteratee<ObjWithSym, string>(symKey)
-        const obj: ObjWithSym = {[symKey]: 'value'}
-        expect(iteratee(obj, 0, [])).toBe('value')
-    })
-
     it('should handle array [key, value] pairs', () => {
         const iteratee = baseIteratee<{name: string; age: number}, boolean>(['name', 'Alice'])
         const obj = {name: 'Alice', age: 30}
@@ -78,18 +53,6 @@ describe('baseIteratee', () => {
         expect(iteratee(5, 0, [])).toBe(false)
     })
 
-    it('should reduce paths correctly with mixed keys (string & number)', () => {
-        const iteratee = baseIteratee<{a: {b?: number}[]}, number>('a.1.b')
-        const obj = {a: [{}, {b: 42}]}
-        expect(iteratee(obj, 0, [])).toBe(42)
-    })
-
-    it('should handle missing keys gracefully', () => {
-        const iteratee = baseIteratee<{a: {b: {c?: number}}}, number | undefined>('a.b.c')
-        const obj = {a: {b: {}}}
-        expect(iteratee(obj, 0, [])).toBeUndefined()
-    })
-
     it('should handle NaN edge case with [key, value] pair', () => {
         const iteratee = baseIteratee<{score: number}, boolean>(['score', NaN])
         const obj = {score: NaN}
@@ -100,20 +63,6 @@ describe('baseIteratee', () => {
         const iteratee = baseIteratee<{score: number}, boolean>({score: NaN})
         const obj = {score: NaN}
         expect(iteratee(obj, 0, [])).toBe(false)
-    })
-
-    it('should handle NaN iteratee', () => {
-        const iteratee = baseIteratee(NaN)
-
-        const arr = ['a', 'b', 'c']
-        expect(iteratee(arr, 0, [])).toBeUndefined()
-    })
-
-    it('should handle NaN iteratee edge case', () => {
-        const iteratee = baseIteratee(NaN)
-
-        const arr = ['a', 'b', 'c']
-        expect(iteratee(arr, 0, [])).toBeUndefined()
     })
 
     it('should handle empty iteratee edge case', () => {
@@ -129,12 +78,5 @@ describe('baseIteratee', () => {
         // @ts-ignore
         const voidIteratee = baseIteratee()
         expect(voidIteratee(arr, 0, [])).toEqual(arr)
-    })
-
-    it('should handle negative integer iteratee edge case with array', () => {
-        const iteratee = baseIteratee(-1)
-
-        const arr = ['a', 'b', 'c']
-        expect(iteratee(arr, 0, [])).toBeUndefined()
     })
 })

--- a/src/internal/baseIteratee.ts
+++ b/src/internal/baseIteratee.ts
@@ -11,19 +11,6 @@ import type {
     ValueKeyIteratee,
 } from './baseIteratee.type'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getValueByPath(element: unknown, path: PropertyName[]): unknown {
-    let result = element
-    for (let i = 0; i < path.length; i++) {
-        if (result == null || typeof result !== 'object') {
-            return undefined
-        }
-        const obj = result as Record<PropertyName, unknown>
-        result = obj[path[i]]
-    }
-    return result
-}
-
 function isMatch(element: unknown, source: unknown): boolean {
     if (!isPlainObject(element) || !isPlainObject(source)) {
         return false
@@ -63,34 +50,6 @@ export function baseIteratee<T, TResult>(iteratee: unknown) {
 
     if (typeof iteratee === 'function') {
         return iteratee
-    }
-
-    if (typeof iteratee === 'string' && !iteratee.includes('.')) {
-        return function (element: T) {
-            if (element == null) {
-                return undefined as TResult
-            }
-            return (element as Record<PropertyName, unknown>)[iteratee] as TResult
-        }
-    }
-
-    if (typeof iteratee === 'string' || typeof iteratee === 'symbol' || typeof iteratee === 'number') {
-        const path = typeof iteratee === 'string' ? iteratee.split('.') : [iteratee]
-
-        return function (element: T) {
-            if (element == null) {
-                return undefined as TResult
-            }
-            // 간단히 getValueByPath 써도 됨
-            let result = element as unknown
-            for (const key of path) {
-                if (result == null) {
-                    return undefined as TResult
-                }
-                result = (result as Record<PropertyName, unknown>)[key]
-            }
-            return result as TResult
-        }
     }
 
     if (isArrayLike(iteratee) && !isFunction(iteratee)) {

--- a/src/internal/baseIteratee.type.ts
+++ b/src/internal/baseIteratee.type.ts
@@ -4,7 +4,7 @@ export type PropertyName = string | number | symbol
 export type PartialShallow<T> = {
     [P in keyof T]?: T[P] extends object ? object : T[P]
 }
-export type IterateeShorthand<T> = PropertyName | [PropertyName, unknown] | PartialShallow<T> | undefined | null
+export type IterateeShorthand<T> = [PropertyName, unknown] | PartialShallow<T> | undefined | null
 
 export type ListIterator<T, TResult> = (value: T, index: number, collection: ArrayLike<T>) => TResult
 export type ListIteratee<T> = ListIterator<T, unknown> | IterateeShorthand<T>

--- a/src/mapValues.bench.ts
+++ b/src/mapValues.bench.ts
@@ -15,14 +15,14 @@ const testCases = [
             user1: {name: 'John', age: 25},
             user2: {name: 'Jane', age: 30},
         },
-        'age',
+        (v: {name: string; age: number}) => v.age,
     ],
     [
         {
             a: {b: {c: 1}},
             x: {b: {c: 2}},
         },
-        'b.c',
+        (v: {b: {c: number}}) => v.b.c,
     ],
 
     // 배열 케이스
@@ -80,7 +80,10 @@ const testCases = [
     // 대량의 작은 객체들
     ...Array(50)
         .fill(0)
-        .map((_, i) => [{value: i, double: i * 2, square: i * i}, 'value']),
+        .map((_, i) => [
+            {value: i, double: i * 2, square: i * i},
+            (v: {value: number; double: number; square: number}) => v.value,
+        ]),
 ] as const
 
 const ITERATIONS = 100

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -115,4 +115,12 @@ describe('mapValues function', () => {
         expect(mapValues(obj, (v) => !v)).toEqual({own: true})
         expect(mapValues(obj, (v) => !v)).toEqual(_mapValues(obj, (v) => !v))
     })
+
+    it('...', () => {
+        const obj = {
+            user1: {name: 'John', age: 25},
+            user2: {name: 'Jane', age: 30},
+        }
+        expect(mapValues(obj, (v) => v.age)).toEqual(_mapValues(obj, (v) => v.age))
+    })
 })

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -15,14 +15,6 @@ describe('mapValues function', () => {
         const obj = {a: 1, b: 2}
         expect(mapValues(obj, (n) => n * 2)).toEqual({a: 2, b: 4})
         expect(mapValues(obj, (n) => n * 2)).toEqual(_mapValues(obj, (n) => n * 2))
-
-        // String iteratee
-        const users = {
-            fred: {user: 'fred', age: 40},
-            pebbles: {user: 'pebbles', age: 1},
-        }
-        expect(mapValues(users, 'age')).toEqual({fred: 40, pebbles: 1})
-        expect(mapValues(users, 'age')).toEqual(_mapValues(users, 'age'))
     })
 
     it('handles array transformations', () => {
@@ -42,15 +34,6 @@ describe('mapValues function', () => {
 
         expect(mapValues(obj, Boolean)).toEqual({a: true, b: true, c: true})
         expect(mapValues(obj, Boolean)).toEqual(_mapValues(obj, Boolean))
-    })
-
-    it('handles nested property paths', () => {
-        const obj = {
-            a: {info: {value: 1}},
-            b: {info: {value: 2}},
-        }
-        expect(mapValues(obj, 'info.value')).toEqual({a: 1, b: 2})
-        expect(mapValues(obj, 'info.value')).toEqual(_mapValues(obj, 'info.value'))
     })
 
     it('handles undefined and null values in objects', () => {

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -39,11 +39,6 @@ describe('pickBy', () => {
         expect(pickBy(obj, predicate)).toEqual(_pickBy(obj, predicate))
     })
 
-    it('should handle object arrays with property name shorthand', () => {
-        const objArray = [{name: 'Alice'}, {age: 25}, {name: 'Bob', age: 30}]
-        expect(pickBy(objArray, 'name')).toEqual(_pickBy(objArray, 'name'))
-    })
-
     it('should handle objects with partial matching using shorthand', () => {
         const objArray = [
             {name: 'Alice', active: true},

--- a/src/some.test.ts
+++ b/src/some.test.ts
@@ -157,11 +157,6 @@ describe('some', () => {
         expect(result.lodash).toBe(result.hidash)
     })
 
-    it('should handle object arrays with property name', () => {
-        const result = compareResults([{name: 'jj'}, {age: 30}], 'name')
-        expect(result.lodash).toBe(result.hidash)
-    })
-
     it('should handle objects with undefined values', () => {
         const result = compareResults({a: undefined, b: 1}, (v) => v === undefined)
         expect(result.lodash).toBe(result.hidash)

--- a/src/sumBy.bench.ts
+++ b/src/sumBy.bench.ts
@@ -14,7 +14,7 @@ interface TestObject {
 
 const testCases = [
     // Empty array
-    [[] as TestObject[], 'value'],
+    [[] as TestObject[], (item: {value: number}) => item.value],
     // Simple array with objects
     [
         [
@@ -22,7 +22,7 @@ const testCases = [
             {value: 2, price: 20, weight: 200},
             {value: 3, price: 30, weight: 300},
         ],
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
     // Array with iteratee function
     [
@@ -40,7 +40,7 @@ const testCases = [
             {nested: {value: 2}, price: 20, weight: 200},
             {nested: {value: 3}, price: 30, weight: 300},
         ],
-        'nested.value',
+        (item: {nested: {value: number}; price: number; weight: number}) => item.nested.value,
     ],
     // Large array
     [
@@ -51,7 +51,7 @@ const testCases = [
                 price: i * 10,
                 weight: i * 100,
             })),
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
     // Array with negative values
     [
@@ -60,7 +60,7 @@ const testCases = [
             {value: -2, price: 20, weight: 200},
             {value: -3, price: 30, weight: 300},
         ],
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
     // Array with decimal values
     [
@@ -69,7 +69,7 @@ const testCases = [
             {value: 0.2, price: 20.5, weight: 200.2},
             {value: 0.3, price: 30.5, weight: 300.3},
         ],
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
     // Complex calculation with iteratee function
     [
@@ -89,7 +89,7 @@ const testCases = [
             {value: 1, price: 10, weight: 100},
             {value: 1, price: 10, weight: 100},
         ],
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
     // Array with zero values
     [
@@ -98,7 +98,7 @@ const testCases = [
             {value: 0, price: 0, weight: 0},
             {value: 0, price: 0, weight: 0},
         ],
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
     // Large numbers
     [
@@ -106,7 +106,7 @@ const testCases = [
             {value: Number.MAX_SAFE_INTEGER, price: 10, weight: 100},
             {value: Number.MAX_SAFE_INTEGER - 1, price: 20, weight: 200},
         ],
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
     // Small numbers
     [
@@ -114,7 +114,7 @@ const testCases = [
             {value: Number.MIN_SAFE_INTEGER, price: 10, weight: 100},
             {value: Number.MIN_SAFE_INTEGER + 1, price: 20, weight: 200},
         ],
-        'value',
+        (item: {value: number; price: number; weight: number}) => item.value,
     ],
 ] as const
 

--- a/src/sumBy.test.ts
+++ b/src/sumBy.test.ts
@@ -40,11 +40,4 @@ describe('sumBy', () => {
             }),
         )
     })
-
-    it('sumBy by string', () => {
-        expect(sumBy(elementOneDepth, 'n')).toBe(20)
-        expect(sumBy(elementOneDepth, 'n')).toBe(_sumBy(elementOneDepth, 'n'))
-        expect(sumBy(elementTwoDepth, 'n.m')).toBe(20)
-        expect(sumBy(elementTwoDepth, 'n.m')).toBe(_sumBy(elementTwoDepth, 'n.m'))
-    })
 })

--- a/src/uniqBy.test.ts
+++ b/src/uniqBy.test.ts
@@ -85,9 +85,6 @@ describe('uniqBy', () => {
 
             const zeroTest: [number[], (x: number) => number] = [[0, -0, 0], (x) => x]
             expect(uniqBy(...zeroTest)).toEqual(_uniqBy(...zeroTest))
-
-            const nanIterateeTest: [string[], number] = [['a', 'b', 'c'], NaN]
-            expect(uniqBy(...nanIterateeTest)).toEqual(_uniqBy(...nanIterateeTest))
         })
 
         it('array-like objects', () => {


### PR DESCRIPTION
# **💥 This PR is BREKING CHANGES, BUT EXPERIMENTAL VERSION**

## This resolves #211

### Description

This PR removes the `PropertyName (string | number | symbol)` typed IterateeShorthand to simplify and improve type safety. 

### Purpose
- Simplify the IterateeShorthand implementation by removing the PropertyName type.
- Ensure that the changes align with project standards and maintain high performance.

### Changes Overview
- Removed the `PropertyName` typed IterateeShorthand.
- Updated relevant tests to reflect this change.
- Verified performance through benchmarks.



