### PR TITLE
length check one time

### DIFF
--- a/.changeset/sharp-symbols-check.md
+++ b/.changeset/sharp-symbols-check.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/hidash": patch
+---
+
+length check one time
+
+PR: [length check one time](https://github.com/NaverPayDev/hidash/pull/240)

--- a/src/difference.ts
+++ b/src/difference.ts
@@ -4,9 +4,11 @@ export function difference<T>(array: ArrayLike<T> | null | undefined, ...values:
     }
 
     const toExclude = new Set<T>()
-    for (let i = 0; i < values.length; i++) {
+    const valueLength = values.length
+    for (let i = 0; i < valueLength; i++) {
         const val = values[i]
-        for (let j = 0; j < val.length; j++) {
+        const valLength = val.length
+        for (let j = 0; j < valLength; j++) {
             toExclude.add(val[j])
         }
     }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -43,7 +43,8 @@ export function filter<T>(collection: T, predicate?: unknown) {
     if (isArrayLike(collection)) {
         const arrayLike = collection as ArrayLike<T>
 
-        for (let index = 0; index < collection.length; index++) {
+        const collectionLength = collection.length
+        for (let index = 0; index < collectionLength; index++) {
             const value = arrayLike[index]
             if ((iteratee as ListIterator<T, boolean>)(value, index, collection)) {
                 result.push(value)

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -44,7 +44,8 @@ export function flow<TArgs extends unknown[]>(
 ): Func<TArgs, unknown> {
     return (...args: TArgs) => {
         let result: unknown = funcs[0](...args)
-        for (let i = 1; i < funcs.length; i++) {
+        const funcLength = funcs.length
+        for (let i = 1; i < funcLength; i++) {
             result = funcs[i](result)
         }
         return result

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -21,7 +21,8 @@ export function groupBy(collection: unknown, iteratee?: ValueIteratee<unknown>):
 
     if (isArrayLike(collection)) {
         const arr = collection as ArrayLike<unknown>
-        for (let i = 0; i < arr.length; i++) {
+        const arrLength = arr.length
+        for (let i = 0; i < arrLength; i++) {
             const value = arr[i]
             const key = iterFn(value, i, arr)
             const stringKey = key == null ? 'undefined' : String(key)
@@ -33,7 +34,8 @@ export function groupBy(collection: unknown, iteratee?: ValueIteratee<unknown>):
 
     if (isPlainObject(collection)) {
         const values = Object.values(collection as Record<PropertyName, unknown>)
-        for (let i = 0; i < values.length; i++) {
+        const valuesLength = values.length
+        for (let i = 0; i < valuesLength; i++) {
             const value = values[i]
             const key = iterFn(value, i, values)
             const stringKey = key == null ? 'undefined' : String(key)

--- a/src/has.ts
+++ b/src/has.ts
@@ -30,10 +30,11 @@ function hasPath(object: unknown, path: PropertyPath): boolean {
     }
 
     const pathArray = isKey(path, object) ? [path as string] : castPath(path)
+    const pathArrayLength = pathArray.length
 
     let currentObject: unknown = object
 
-    for (let i = 0; i < pathArray.length; i++) {
+    for (let i = 0; i < pathArrayLength; i++) {
         const key = pathArray[i]
 
         if (

--- a/src/internal/baseIteratee.ts
+++ b/src/internal/baseIteratee.ts
@@ -19,7 +19,8 @@ function isMatch(element: unknown, source: unknown): boolean {
     const sourceObj = source as Record<PropertyName, unknown>
 
     const keys = Object.keys(sourceObj)
-    for (let i = 0; i < keys.length; i++) {
+    const keyLength = keys.length
+    for (let i = 0; i < keyLength; i++) {
         const key = keys[i]
         const value = sourceObj[key]
         const elementValue = elementObj[key]

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -19,7 +19,8 @@ export function omit<T extends object>(object: T | null | undefined, ...paths: P
         }
     }
 
-    for (let i = 0; i < flattenedPaths.length; i++) {
+    const size = flattenedPaths.length
+    for (let i = 0; i < size; i++) {
         delete result[flattenedPaths[i] as keyof T]
     }
 

--- a/src/shuffle.ts
+++ b/src/shuffle.ts
@@ -11,7 +11,8 @@ export function shuffle<T>(collection: Collection<T> | null | undefined): T[] {
     if (collection instanceof Map) {
         result = []
         const entries = Array.from(collection.entries())
-        for (let i = 0; i < entries.length; i++) {
+        const entriesLength = entries.length
+        for (let i = 0; i < entriesLength; i++) {
             result.push(entries[i][0] as unknown as T)
             result.push(entries[i][1] as T)
         }

--- a/src/some.ts
+++ b/src/some.ts
@@ -35,7 +35,8 @@ export function some<T>(
     if (isArrayLike(collection)) {
         const arrayLike = collection as ArrayLike<T>
 
-        for (let i = 0; i < collection.length; i++) {
+        const collectionLength = collection.length
+        for (let i = 0; i < collectionLength; i++) {
             if (iteratee(arrayLike[i], i, arrayLike)) {
                 return true
             }

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -3,7 +3,8 @@
  */
 export function sum(elements: number[]): number {
     let result = 0
-    for (let i = 0; i < elements.length; i++) {
+    const elementLength = elements.length
+    for (let i = 0; i < elementLength; i++) {
         result += elements[i]
     }
     return result

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -14,7 +14,8 @@ export function transform<T extends readonly unknown[] | Record<PropertyKey, unk
 
     if (isArr) {
         const arr = obj as unknown[]
-        for (let i = 0; i < arr.length; i++) {
+        const size = arr.length
+        for (let i = 0; i < size; i++) {
             const key = i as Keys<T>
             const value = arr[i] as ValueOf<T>
             const result = iteratee(acc, value, key, obj)

--- a/src/union.ts
+++ b/src/union.ts
@@ -1,11 +1,13 @@
 export function union<T>(...arrays: (T[] | null | undefined)[]): T[] {
     const result: T[] = []
     const seen = new Map<T, boolean>()
+    const arrayLength = arrays.length
 
-    for (let i = 0; i < arrays.length; i++) {
+    for (let i = 0; i < arrayLength; i++) {
         const array = arrays[i]
         if (array) {
-            for (let j = 0; j < array.length; j++) {
+            const length = array.length
+            for (let j = 0; j < length; j++) {
                 const item = array[j]
                 if (!seen.has(item)) {
                     seen.set(item, true)

--- a/src/uniqBy.ts
+++ b/src/uniqBy.ts
@@ -11,8 +11,9 @@ export function uniqBy<T>(array: List<T> | null | undefined, iteratee: ValueIter
     const seen = new Map<unknown, boolean>()
     const result: T[] = []
     const iterateeFn = baseIteratee(iteratee)
+    const arrayLength = array.length
 
-    for (let i = 0; i < array.length; i++) {
+    for (let i = 0; i < arrayLength; i++) {
         const value = array[i]
         const computed = iterateeFn(value, i, array)
 


### PR DESCRIPTION
## This resolves <!-- add issue number -->

for 문을 만족하는 조건을 확인할때 배열의 length 를 직접 사용하게 되면, 해당 배열의 length 를 참조하는데 일정 비용이 드는 것으로 알고 있습니다.

하여 이를 array.length 를 변수에 저장해두고 사용해두면 참조하는 비용을 줄일 수 있을것으로 기대됩니다.

## 고민사항

- BenchmarkREADME 에 있는 결과 보다 나아졌는가?
  - 나아진 부분도 있고 떨어진 부분도 있지만, 결과적으로 더 나은 방향으로 결정
- action 이 동일하게 동작하는 부분 확인완료
  - comment 가 업데이트 되지 않는 부분이 있는 것 같아 다음 PR 에서 확인 필요