### PR TITLE
fix: update CI badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please read our contributing guidelines before submitting PRs.
 
 ## License
 
-MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+MIT License - see the [LICENSE.md](LICENSE) file for details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @naverpay/hidash
 
-[![CI](https://github.com/NaverPayDev/hidash/actions/workflows/ci.yaml/badge.svg)](https://github.com/NaverPayDev/hidash/actions/workflows/matrix.yaml)
+[![CI](https://github.com/NaverPayDev/hidash/actions/workflows/matrix.yaml/badge.svg)](https://github.com/NaverPayDev/hidash/actions/workflows/matrix.yaml)
 
 A modern, performance-focused alternative to Lodash.
 


### PR DESCRIPTION
**Before**
<img width="915" alt="스크린샷 2025-04-30 오후 1 49 58" src="https://github.com/user-attachments/assets/e04bfa45-ea83-4fbd-b969-7b95eff19728" />

**After**
<img width="1032" alt="스크린샷 2025-04-30 오후 1 51 04" src="https://github.com/user-attachments/assets/80ce1d74-45e7-4ef4-8733-93587038f91d" />
