### PR TITLE
docs: Enhance JSDoc and internal comments for core utility functions

### DIFF
--- a/src/before.ts
+++ b/src/before.ts
@@ -1,22 +1,44 @@
+/**
+ * @description
+ * Creates a function that invokes `func` as long as it's called less than `initialN` times.
+ * Subsequent calls to the new function return the result of the last `func` invocation.
+ * This behavior is similar to lodash's `_.before` function.
+ *
+ * @template T - The type of the function to restrict.
+ * @param {number} initialN - The number determining how many times `func` can be called.
+ * `func` is invoked if called less than `initialN` times (i.e., up to `initialN - 1` times).
+ * If `initialN` is less than or equal to 1, `func` will not be invoked.
+ * @param {T} func - The function to restrict.
+ * @returns {(...args: Parameters<T>) => ReturnType<T>} Returns the new restricted function.
+ * @throws {TypeError} If `func` is not a function.
+ */
 export function before<T extends (...args: Parameters<T>) => ReturnType<T>>(
     initialN: number,
     func: T,
 ): (...args: Parameters<T>) => ReturnType<T> {
+    // Ensure `func` is a function, otherwise throw an error.
     if (typeof func !== 'function') {
         throw new TypeError('Expected a function')
     }
 
     let result: ReturnType<T>
+    // Ensure 'n' is an integer. It tracks the remaining times `func` can be called before it's restricted.
     let n = Math.floor(initialN)
 
     return function (this: ThisParameterType<T>, ...args: Parameters<T>): ReturnType<T> {
+        // Decrement n. If n is still greater than 0 after decrementing, it means func can be invoked.
+        // This allows func to be called `initialN - 1` times if initialN was originally > 1.
         if (--n > 0) {
             result = func.apply(this, args)
         }
+        // If `n` has reached 1 or less (meaning `func` has been called the intended maximum times,
+        // or was not supposed to be called at all if initialN was <=1),
+        // disassociate `func` to prevent further calls and aid garbage collection.
         if (n <= 1) {
             // eslint-disable-next-line no-param-reassign
-            func = undefined as unknown as T
+            func = undefined as unknown as T // Original func is no longer needed.
         }
+        // Return the result of the last actual invocation, or undefined if never invoked.
         return result
     }
 }

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,17 +1,37 @@
 /**
- * @description https://unpkg.com/lodash@4.17.21/chunk.js
+ * @description
+ * Creates an array of elements split into groups the length of `size`.
+ * If `array` can't be split evenly, the final chunk will be the remaining elements.
+ * This function is similar to lodash's `_.chunk`.
+ * (Original source inspiration for Lodash version: https://unpkg.com/lodash@4.17.21/chunk.js)
+ *
+ * @template T - The type of elements in the array.
+ * @param {T[] | null | undefined} array - The array to process.
+ * @param {number} [size=1] - The length of each chunk. Defaults to 1.
+ * If `size` is less than 1, an empty array is returned.
+ * @returns {T[][]} Returns the new array of chunks, or an empty array if the input
+ * array is null/undefined or size is invalid.
  */
 export function chunk<T>(array: T[] | null | undefined, size: number = 1): T[][] {
+    // Guard clause: if the array is null/undefined or size is less than 1,
+    // return an empty array as no valid chunking can be performed.
     if (!array || size < 1) {
         return []
     }
 
+    // Determine the actual size for each chunk.
+    // It's the floored value of `size`, but never less than 1.
+    // (e.g., if size is 2.5, chunks will be of size 2).
     const absoluteSize = Math.max(Math.floor(size), 1)
-    const length = array.length
+    const length = array.length // Cache array length for minor performance optimization.
+
+    // Pre-allocate the result array with the calculated number of chunks needed.
     const result: T[][] = new Array(Math.ceil(length / absoluteSize))
 
-    let resIndex = 0
+    let resIndex = 0 // Index for populating the result array.
+    // Iterate over the input array, incrementing by `absoluteSize` in each step.
     for (let i = 0; i < length; i += absoluteSize) {
+        // Extract a chunk from the array using `slice` and add it to the result array.
         result[resIndex++] = array.slice(i, i + absoluteSize)
     }
 

--- a/src/clamp.ts
+++ b/src/clamp.ts
@@ -1,20 +1,66 @@
 /**
+ * @description
+ * Clamps `number` within inclusive bounds. The interpretation of `bounds` and `upperBound` arguments
+ * determines the effective lower and upper limits for clamping:
+ *
+ * 1.  **If `upperBound` is `undefined` (e.g., `clamp(number, singleBound)`):**
+ * - `bounds` (the second argument) is treated as the **upper** limit.
+ * - There is no explicit lower limit defined by the parameters. In this scenario, for the internal logic,
+ * `number` itself effectively acts as the floor in the `Math.max(number, floor_value)` step,
+ * meaning clamping primarily occurs against the provided upper limit.
+ *
+ * 2.  **If `upperBound` is provided (e.g., `clamp(number, lowerLimit, upperLimit)`):**
+ * - `bounds` (the second argument) is treated as the **lower** limit.
+ * - `upperBound` (the third argument) is treated as the **upper** limit.
+ *
+ * Special handling for `NaN` values:
+ * - If the input `number` itself is `NaN`, the function returns `NaN`.
+ * - If any of the determined effective lower or upper limits (after parameter resolution and defaulting)
+ * is `NaN`, the function returns `0`.
+ *
+ * This function is conceptually similar to Lodash's `_.clamp`, but specific behaviors (like
+ * `NaN` handling for bounds and parameter interpretation) might differ from the linked Lodash version.
  * @see https://unpkg.com/lodash.clamp@4.0.3/index.js
+ *
+ * @param {number} number - The number to clamp.
+ * @param {number} [bounds] - This argument's role depends on `upperBound`.
+ * If `upperBound` is undefined, `bounds` acts as the upper limit.
+ * Otherwise, `bounds` acts as the lower limit.
+ * @param {number} [upperBound] - If provided, this is the upper limit, and the `bounds`
+ * argument is treated as the lower limit.
+ * @returns {number} The clamped number. Returns `NaN` if the input `number` is `NaN`.
+ * Returns `0` if the determined effective bounds are `NaN`.
  */
 export function clamp(number: number, bounds?: number, upperBound?: number): number {
+    // Determine the actual lower and upper bounds based on whether `upperBound` is provided.
+    // Case 1: Called as clamp(num, upper_val) -> lowerBound is undefined, finalUpperBound is `bounds` (upper_val).
+    // Case 2: Called as clamp(num, lower_val, upper_val) -> lowerBound is `bounds` (lower_val), finalUpperBound is `upperBound` (upper_val).
     const [lowerBound, finalUpperBound] = upperBound === undefined ? [undefined, bounds] : [bounds, upperBound]
 
+    // If the number to be clamped is NaN, return NaN immediately as per typical NaN propagation.
     if (isNaN(number)) {
         return NaN
     }
 
+    // Resolve the effective lower bound for clamping.
+    // If `lowerBound` is undefined (e.g., when only one bound argument, acting as upper, was provided),
+    // `number` itself is used. This means Math.max(number, number) occurs, effectively not applying a separate lower clamp.
     const lower = lowerBound ?? number
+
+    // Resolve the effective upper bound for clamping.
+    // If `finalUpperBound` is undefined (e.g., if `bounds` was `undefined` in the single-bound argument scenario),
+    // `number` itself is used, effectively not applying a separate upper clamp.
     const upper = finalUpperBound ?? number
 
+    // Specific behavior: if either of the determined effective bounds is NaN, the function returns 0.
+    // This differs from some clamp implementations but is the defined behavior here.
     if (isNaN(lower) || isNaN(upper)) {
         return 0
     }
 
+    // Apply the clamping logic:
+    // Math.max ensures the number is not less than the lower bound.
+    // Math.min ensures the result of that is not greater than the upper bound.
     return Math.min(Math.max(number, lower), upper)
 }
 

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,57 +1,96 @@
-import isArray from './isArray'
-import isObject from './isObject'
+import isArray from './isArray' // Assuming isArray correctly checks for Array type
+import isObject from './isObject' // Assuming isObject correctly checks for 'plain' Object type
 
+/**
+ * @description
+ * Creates a shallow clone of `value`. This function handles primitives, null, and common
+ * JavaScript object types such as Array, Date, RegExp, TypedArray (excluding DataView),
+ * ArrayBuffer, Map, Set, and plain objects.
+ * For plain objects, the clone will have the same prototype and a copy of its own
+ * enumerable properties (both String-keyed and Symbol-keyed).
+ * This function is similar in purpose to lodash's `_.clone` (which also performs a shallow clone).
+ *
+ * @template T - The type of the value to clone.
+ * @param {T} value - The value to clone.
+ * @returns {T} Returns the shallow cloned value.
+ */
 export function clone<T>(value: T): T {
+    // Primitives (string, number, boolean, undefined, symbol, bigint) and null
+    // are returned directly as they are immutable or effectively passed by value.
     if (value === null || typeof value !== 'object') {
         return value
     }
 
+    // For Arrays, create a shallow copy using the slice method.
+    // `value.slice()` creates a new array with its elements shallowly copied.
     if (isArray(value)) {
         return value.slice() as T
     }
 
+    // For Date objects, create a new Date instance with the same time value.
     if (value instanceof Date) {
         return new Date(value.getTime()) as T
     }
 
+    // For RegExp objects, create a new RegExp instance with the same source and flags.
     if (value instanceof RegExp) {
         return new RegExp(value.source, value.flags) as T
     }
 
+    // Handle TypedArrays (e.g., Uint8Array, Int32Array, etc.),
+    // explicitly excluding DataView which might require different handling or is not supported here.
     if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+        // Get the specific TypedArray constructor (e.g., Uint8Array, Float32Array).
         const TypedArrayConstructor = value.constructor as new (buffer: ArrayBuffer) => ArrayBufferView
+        // Create a new TypedArray instance. Its underlying ArrayBuffer is a shallow copy
+        // of the original TypedArray's buffer. `value.buffer.slice(0)` creates this new buffer.
         return new TypedArrayConstructor(value.buffer.slice(0) as ArrayBuffer) as T
     }
 
+    // For ArrayBuffer objects, create a shallow copy using the slice method.
+    // `value.slice(0)` creates a new ArrayBuffer with a copy of the original's bytes.
     if (value instanceof ArrayBuffer) {
         return value.slice(0) as T
     }
 
+    // For Map objects, create a new Map. The constructor `new Map(iterable)`
+    // performs a shallow copy of the key-value pairs from the original Map.
     if (value instanceof Map) {
         return new Map(value) as T
     }
 
+    // For Set objects, create a new Set. The constructor `new Set(iterable)`
+    // performs a shallow copy of the values from the original Set.
     if (value instanceof Set) {
         return new Set(value) as T
     }
 
+    // Handle plain objects (or objects considered as such by the `isObject` helper).
+    // This typically targets objects created via `{}` literals or `new Object()`.
     if (isObject(value)) {
+        // Create a new object with the same prototype as the original object.
         const result = Object.create(Object.getPrototypeOf(value))
 
+        // Shallow copy own enumerable string-keyed properties from `value` to `result`.
         Object.assign(result, value)
 
+        // Shallow copy own enumerable symbol-keyed properties, as Object.assign does not handle these.
         const symbols = Object.getOwnPropertySymbols(value)
-        if (symbols.length) {
+        if (symbols.length > 0) {
             symbols.forEach((sym) => {
+                // Check if the symbol property is enumerable on the original object.
                 if (Object.prototype.propertyIsEnumerable.call(value, sym)) {
                     result[sym] = value[sym as keyof typeof value]
                 }
             })
         }
-
         return result as T
     }
 
+    // Fallback for any other 'object' types not explicitly handled by the conditions above
+    // and not matching `isObject`. This returns a new, empty plain object cast to type T.
+    // Warning: This may not produce the desired clone for all unhandled complex object types,
+    // as it discards all data and specific type information, effectively returning `{}`.
     return {} as T
 }
 

--- a/src/cloneDeep.ts
+++ b/src/cloneDeep.ts
@@ -1,64 +1,120 @@
 import {FUNCTION_TAG, WEAK_SET_TAG, WEAK_MAP_TAG} from './internal/to-string-tags'
 import isArray from './isArray'
 
+/**
+ * @description
+ * Creates a deep clone of `value`. This function recursively clones nested objects and arrays.
+ * It includes basic handling for circular references by returning an empty object (`{}`)
+ * for objects already encountered during the current cloning process.
+ *
+ * Key behaviors and limitations for specific types:
+ * - **Primitives** (string, number, boolean, null, undefined, symbol, bigint): Returned as-is.
+ * - **Arrays**: A new array is created, and its elements are deep cloned.
+ * - **Maps**: A new Map is created. Its values are deep cloned; keys are assigned by reference.
+ * - **Sets**: A new Set is created, and its values are deep cloned.
+ * - **Plain Objects** (specifically, those where `Object.prototype.toString.call(v)` returns `[object Object]`):
+ * A new object is created with the same prototype, and its own enumerable properties are deep cloned.
+ * - **Functions, WeakMaps, WeakSets**: An empty object (`{}`) is returned. These types are not deeply cloned by this implementation.
+ * - **Circular References**: When a circular reference is detected, an empty object (`{}`) is returned for that reference point
+ * to break the cycle, meaning the original circular structure is not fully replicated.
+ * - **Other Object Types (e.g., Date, RegExp, TypedArray, ArrayBuffer, custom class instances not matching `[object Object]`):
+ * These types are **returned by reference (i.e., NOT cloned)**. This is a significant limitation for a "deep" clone.
+ *
+ * This function is conceptually similar to lodash's `_.cloneDeep` but has notable
+ * differences in its handling of certain types, circular references, and overall completeness.
+ * It is a simplified implementation.
+ *
+ * @template T - The type of the value to clone.
+ * @param {T} value - The value to deeply clone.
+ * @returns {T} Returns the deeply cloned value, subject to the specific behaviors and limitations noted above.
+ */
 export function cloneDeep<T>(value: T): T {
+    // `seen` tracks objects already processed in the current cloning operation.
+    // This is crucial for handling circular references and preventing infinite loops.
     const seen = new WeakSet()
 
+    // Inner recursive helper function that performs the actual deep cloning.
     function deepClone<R>(v: R): R {
+        // Get the internal [[Class]] string tag for more precise type checking.
         const type = Object.prototype.toString.call(v)
 
+        // Functions, WeakMaps, and WeakSets are complex to clone deeply or their identity is key.
+        // This implementation opts to return a new empty object for them, signifying they are not cloned.
         if (type === WEAK_MAP_TAG || type === WEAK_SET_TAG || type === FUNCTION_TAG) {
-            return {} as R
+            return {} as R // Design choice: return an empty object.
         }
 
+        // Primitives (string, number, etc.) and null are immutable or passed by value,
+        // so they don't need cloning and can be returned directly.
         if (v === null || typeof v !== 'object') {
             return v
         }
 
+        // Handle circular references: If this object has already been encountered in the
+        // current cloning path (i.e., it's part of a cycle), return an empty object.
+        // This breaks the infinite loop but means the circular structure isn't replicated with the original reference.
         if (seen.has(v)) {
-            return {} as R
+            return {} as R // Design choice: return an empty object for circular references.
         }
+        // Add the current object to the `seen` set before processing its properties/elements.
         seen.add(v as object)
 
+        // If the value is an array, create a new array and deep clone each of its elements.
         if (isArray(v)) {
+            // Using `any[]` temporarily for `result` simplifies pushing mixed-type cloned items.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const result: any[] = []
             v.forEach((item) => {
-                result.push(deepClone(item))
+                result.push(deepClone(item)) // Recursively clone each array element.
             })
+            // Cast the result back to the expected generic type R.
             return result as unknown as R
         }
 
+        // If the value is a Map, create a new Map.
+        // Keys are assigned by reference; values are deep cloned.
         if (v instanceof Map) {
             const result = new Map()
             v.forEach((item, k) => {
-                result.set(k, deepClone(item))
+                result.set(k, deepClone(item)) // `k` (key) is by reference, `item` (value) is deep cloned.
             })
             return result as unknown as R
         }
 
+        // If the value is a Set, create a new Set and deep clone each of its elements.
         if (v instanceof Set) {
             const result = new Set()
             v.forEach((item) => {
-                result.add(deepClone(item))
+                result.add(deepClone(item)) // Recursively clone each Set element.
             })
             return result as unknown as R
         }
 
+        // Handle plain JavaScript objects (those identified by `Object.prototype.toString.call(v) === '[object Object]'`).
         if (type === '[object Object]') {
-            const proto = Object.getPrototypeOf(v)
-            const result = Object.create(proto)
+            const proto = Object.getPrototypeOf(v) // Get the prototype of the original object.
+            const result = Object.create(proto) // Create the new object with the same prototype.
+
+            // Iterate over all enumerable properties (own and potentially inherited via `for...in`).
             for (const key in v) {
+                // Ensure that we only copy own properties, not inherited ones.
                 if (Object.prototype.hasOwnProperty.call(v, key)) {
+                    // Recursively deep clone the value of each own property.
                     result[key] = deepClone((v as Record<string, unknown>)[key])
                 }
             }
             return result as R
         }
 
+        // Fallback for any other object types not explicitly handled above.
+        // This includes types like Date, RegExp, TypedArrays, ArrayBuffer, DataView,
+        // and custom class instances that don't have `[object Object]` as their string tag.
+        // These objects are returned by reference, meaning they are NOT deeply cloned.
+        // This is a significant limitation of this simplified `cloneDeep` version.
         return v
     }
 
+    // Start the deep cloning process with the initial value.
     return deepClone(value)
 }
 


### PR DESCRIPTION
This PR updates inline documentation for key utility functions by adding JSDoc headers and internal comments. The main goal is to boost code readability and maintainability, ensuring consistency with our commenting guidelines.

No functional code has been changed.

**Functions Updated:**

- `before`
- `chunk`
- `clamp`
- `clone` (shallow clone)
- `cloneDeep`

The new comments clarify each function's purpose, parameters, return values, and important implementation details or limitations.