### PR TITLE
feat: add benchmark for last 

### DIFF
--- a/src/last.bench.ts
+++ b/src/last.bench.ts
@@ -1,0 +1,41 @@
+import _last from 'lodash/last'
+import {bench, describe} from 'vitest'
+
+import {last} from './last'
+
+const testCases = [
+    null,
+    undefined,
+    ['a', 'b', 'c'],
+    [1, 2, 3],
+    [],
+    new Array(3),
+    [null],
+    [undefined],
+    [false],
+    [0],
+    [''],
+    [1, 'string', null, undefined, false],
+    new Array(1000).fill(0).map((_, i) => i),
+    Object('hello'),
+]
+
+const ITERATIONS = 1000
+
+describe('last performance', () => {
+    bench('hidash', () => {
+        for (let i = 0; i < ITERATIONS; i++) {
+            testCases.forEach((testCase) => {
+                last(testCase)
+            })
+        }
+    })
+
+    bench('lodash', () => {
+        for (let i = 0; i < ITERATIONS; i++) {
+            testCases.forEach((testCase) => {
+                _last(testCase)
+            })
+        }
+    })
+})

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -12,9 +12,6 @@ describe('last function', () => {
     })
 
     test('returns last element for arrays', () => {
-        expect(last([])).toBeUndefined()
-        expect(last([])).toEqual(_last([]))
-
         const arr = ['a', 'b', 'c']
         expect(last(arr)).toBe('c')
         expect(last(arr)).toEqual(_last(arr))


### PR DESCRIPTION
Added `last.bench.ts` for performance comparison with Lodash.  
Removed duplicated test cases from `last.test.ts`.

![스크린샷 2025-05-14 오후 8 20 16](https://github.com/user-attachments/assets/32ee1c75-48f4-4f36-83fc-ba113caa08dd)

![스크린샷 2025-05-14 오후 8 20 34](https://github.com/user-attachments/assets/c53459f1-4b51-45e1-96c2-3743fbe2f171)
