### PR TITLE
 fix(isEqual): support deep equality for Map and Set instances 

### DIFF
--- a/.changeset/light-books-smell.md
+++ b/.changeset/light-books-smell.md
@@ -1,0 +1,5 @@
+---
+'@naverpay/hidash': patch
+---
+
+fix(isEqual): support deep equality for Map and Set instances

--- a/src/isEqual.test.ts
+++ b/src/isEqual.test.ts
@@ -44,4 +44,76 @@ describe('isEqual', () => {
     ])('should not be equal %o and %o', (a, b) => {
         expect(isEqual(a, b)).toEqual(_isEqual(a, b))
     })
+
+    describe('Map', () => {
+        it('should treat empty Maps as equal', () => {
+            expect(isEqual(new Map(), new Map())).toEqual(_isEqual(new Map(), new Map()))
+        })
+
+        it('should treat Maps with same entries as equal', () => {
+            expect(isEqual(new Map([[1, 'a']]), new Map([[1, 'a']]))).toEqual(
+                _isEqual(new Map([[1, 'a']]), new Map([[1, 'a']])),
+            )
+        })
+
+        it('should treat Maps with different values as not equal', () => {
+            expect(isEqual(new Map([[1, 'a']]), new Map([[1, 'b']]))).toEqual(
+                _isEqual(new Map([[1, 'a']]), new Map([[1, 'b']])),
+            )
+        })
+
+        it('should treat Maps with different keys as not equal', () => {
+            expect(isEqual(new Map([[1, 'a']]), new Map([[2, 'a']]))).toEqual(
+                _isEqual(new Map([[1, 'a']]), new Map([[2, 'a']])),
+            )
+        })
+
+        it('should treat Maps with different sizes as not equal', () => {
+            expect(
+                isEqual(
+                    new Map([
+                        [1, 'a'],
+                        [2, 'b'],
+                    ]),
+                    new Map([[1, 'a']]),
+                ),
+            ).toEqual(
+                _isEqual(
+                    new Map([
+                        [1, 'a'],
+                        [2, 'b'],
+                    ]),
+                    new Map([[1, 'a']]),
+                ),
+            )
+        })
+
+        it('should not treat a Map and a plain object as equal', () => {
+            expect(isEqual(new Map(), {})).toEqual(_isEqual(new Map(), {}))
+        })
+    })
+
+    describe('Set', () => {
+        it('should treat empty Sets as equal', () => {
+            expect(isEqual(new Set(), new Set())).toEqual(_isEqual(new Set(), new Set()))
+        })
+
+        it('should treat Sets with same values as equal', () => {
+            expect(isEqual(new Set([1, 2, 3]), new Set([1, 2, 3]))).toEqual(
+                _isEqual(new Set([1, 2, 3]), new Set([1, 2, 3])),
+            )
+        })
+
+        it('should treat Sets with different values as not equal', () => {
+            expect(isEqual(new Set([1, 2]), new Set([1, 3]))).toEqual(_isEqual(new Set([1, 2]), new Set([1, 3])))
+        })
+
+        it('should treat Sets with different sizes as not equal', () => {
+            expect(isEqual(new Set([1, 2]), new Set([1]))).toEqual(_isEqual(new Set([1, 2]), new Set([1])))
+        })
+
+        it('should not treat a Set and an Array as equal', () => {
+            expect(isEqual(new Set([1, 2]), [1, 2])).toEqual(_isEqual(new Set([1, 2]), [1, 2]))
+        })
+    })
 })

--- a/src/isEqual.ts
+++ b/src/isEqual.ts
@@ -29,11 +29,36 @@ export function isEqual(value: unknown, other: unknown) {
     }
 
     if (typeof value === 'object' && value !== null && typeof other === 'object' && other !== null) {
-        const valueObject = value as Record<string, unknown>
-        const otherObject = other as Record<string, unknown>
-        if (Object.getPrototypeOf(valueObject) !== Object.getPrototypeOf(otherObject)) {
+        if (Object.getPrototypeOf(value) !== Object.getPrototypeOf(other)) {
             return false
         }
+
+        if (value instanceof Map && other instanceof Map) {
+            if (value.size !== other.size) {
+                return false
+            }
+            for (const [k, v] of value) {
+                if (!other.has(k) || !isEqual(v, other.get(k))) {
+                    return false
+                }
+            }
+            return true
+        }
+
+        if (value instanceof Set && other instanceof Set) {
+            if (value.size !== other.size) {
+                return false
+            }
+            for (const v of value) {
+                if (!other.has(v)) {
+                    return false
+                }
+            }
+            return true
+        }
+
+        const valueObject = value as Record<string, unknown>
+        const otherObject = other as Record<string, unknown>
 
         const valueKeys = Object.keys(valueObject)
         const otherKeys = Object.keys(otherObject)


### PR DESCRIPTION
 ## Problem
                                                                                     
  `Object.keys()` returns no entries for Map/Set, so two instances with different    
  contents were always considered equal.
                                                                                     
  ```ts                                                                             
  isEqual(new Map([[1, 'a']]), new Map([[1, 'b']])) // true (wrong)
  isEqual(new Set([1, 2]), new Set([1, 3]))          // true (wrong)                 
  ```                                                                               
  
  ## Solution                                                                        
                  
  - `Map`: compare size, then verify each key-value pair via `has`/`get`             
  - `Set`: compare size, then verify each element via `has`
  - Add test cases for both types                                                    
                  